### PR TITLE
close Dtrader new modal

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -100,8 +100,11 @@ Cypress.Commands.add('c_doOAuthLogin', (app) => {
   cy.c_visitResponsive(Cypress.env("oAuthUrl"),"large")
   //To let the dtrader page load completely
   cy.get('.cq-symbol-select-btn', { timeout: 10000}).should('exist')
-
-  //If Deriv charts popup exists, click continue
+  cy.findByTestId('launch-modal').then(($element) =>{
+    if($element){
+      cy.findByRole('button', { name: 'Ok' }).click();
+    }
+  })
   cy.get('#modal_root, .modal-root', { timeout: 10000 })
     .then(($element) => {
       if ($element.children().length > 0) {


### PR DESCRIPTION
this PR close the new Dtrader modal which cause failure in all of the wallet tests