### PR TITLE
Update e2e.js

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -123,11 +123,6 @@ Cypress.Commands.add('c_doOAuthLogin', (app) => {
         if (app == "wallets" || app == "doughflow"  || app == "demoonlywallet" || app == "onramp") {
           cy.findByRole('banner').should("be.visible")
           } else { //when deriv charts popup is not available and if we need to redirect to trader's hub page
-            cy.get('div[data-testid="dt_modal_footer"]').find('button:nth-child(2)').then(($buttons) => {
-              if ($buttons.length) {
-                cy.wrap($buttons).click()
-              }
-            });
             cy.findByText("Trader's Hub").should("be.visible")
           }
       }


### PR DESCRIPTION
Removing the redundant code to close turbo popup as it's already there at the top of the command. This piece of code was trying to find a popup which has already been closed so tests were failing.