### PR TITLE
remove pixelmatch in workflow

### DIFF
--- a/.github/workflows/cypress_cloud_manual.yml
+++ b/.github/workflows/cypress_cloud_manual.yml
@@ -47,9 +47,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: deriv-com/e2e-deriv-app # Replace with your repository name
-    
-    - name: Install pixelmatch
-      run: npm install pixelmatch
       
     - name: Create server URL
       if: ${{github.event.inputs.qabox !='' }}


### PR DESCRIPTION
This PR is to remove pixelmatch installation in workflow. This is mistakenly added in the previous PR, the pixelmatch has been included in the package.json, so no needed in the workflow.