### PR TITLE
Usman/delete payment method p2p in responsive mode - Refactored editPaymentMethods - common.js

### DIFF
--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -1,3 +1,4 @@
+/// <reference types="cypress" />
 import '@testing-library/cypress/add-commands'
 
 let paymentMethod = null
@@ -29,9 +30,33 @@ function deletePaymentMethod() {
     })
 }
 
-function addNewPaymentMethod() {
-    
+function generateAccountNumberString(length) {
+    let result = ''
+    const characters = '0123456789'
+    const charactersLength = characters.length
+    for (let i = 0; i < length; i++) {
+        result += characters.charAt(Math.floor(Math.random() * charactersLength))
+    }
+    return result
+}
 
+function setText(fieldName, fieldText) {
+    cy.findByRole('textbox', { name: fieldName }).clear().type(fieldText).should('have.value', fieldText)
+}
+
+function addPaymentMethod() {
+    const accountNumberString = generateAccountNumberString(12)
+    cy.findByRole('button').should('be.visible').and('contain.text', 'Add').click()
+    setText('Payment method', 'Bank Transfer')
+    cy.findByText('Bank Transfer').click()
+    setText('Account Number', accountNumberString)
+    setText('SWIFT or IFSC code', '9087')
+    setText('Bank Name', 'Bank Alfalah TG')
+    setText('Branch', 'Branch number 42')
+    cy.get('textarea[name="instructions"]').type('Follow instructions.').should('have.value', 'Follow instructions.')
+    cy.findByRole('button', { name: 'Add' }).should('not.be.disabled').click()
+    cy.findByText('Payment methods').should('be.visible')
+    cy.findByText(accountNumberString).should('be.visible')
 }
 
 describe("QATEST-2839 - My Profile page - Delete Payment Method", () => {
@@ -48,9 +73,9 @@ describe("QATEST-2839 - My Profile page - Delete Payment Method", () => {
         cy.findByText('Available Deriv P2P balance').should('be.visible')
         cy.findByText('Payment methods').should('be.visible').click()
         cy.findByText('Payment methods').should('be.visible')
-        addNewPaymentMethod()
+        addPaymentMethod()
         cy.get('span.payment-methods-list__list-header').first().invoke('text').then((value) => {
-            paymentMethod = value.trim() //Will only get either of the three: Bank Transfers, E-wallets, Others
+            paymentMethod = value.trim()
             cy.log("Payment type available: " + paymentMethod)
             cy.contains('div.payment-methods-list__list-container span', paymentMethod).next().within(() => {
                 deletePaymentMethod()

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -29,6 +29,11 @@ function deletePaymentMethod() {
     })
 }
 
+function addNewPaymentMethod() {
+    
+
+}
+
 describe("QATEST-2839 - My Profile page - Delete Payment Method", () => {
     beforeEach(() => {
         cy.c_login()
@@ -43,6 +48,7 @@ describe("QATEST-2839 - My Profile page - Delete Payment Method", () => {
         cy.findByText('Available Deriv P2P balance').should('be.visible')
         cy.findByText('Payment methods').should('be.visible').click()
         cy.findByText('Payment methods').should('be.visible')
+        addNewPaymentMethod()
         cy.get('span.payment-methods-list__list-header').first().invoke('text').then((value) => {
             paymentMethod = value.trim() //Will only get either of the three: Bank Transfers, E-wallets, Others
             cy.log("Payment type available: " + paymentMethod)

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -18,7 +18,7 @@ function deletePaymentMethod() {
         }
         if (value !== '') {
             paymentID = $span.text().trim()
-            if (paymentName && paymentName != '' && paymentID) {
+            if (paymentName && paymentID) {
                 cy.findAllByTestId('dt_dropdown_display').first().click()
                 cy.get('#delete').should('be.visible').click()
                 cy.get('div[class="dc-modal-header"]', { withinSubject: null }).should('be.visible').and('exist').contains(`Delete ${paymentName}?`)

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -1,4 +1,3 @@
-/// <reference types="cypress" />
 import '@testing-library/cypress/add-commands'
 
 let paymentMethod = null

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -8,13 +8,11 @@ function navigateToTab(tabName) {
 }
 
 function deletePaymentMethod() {
-    cy.contains('div.payment-method-card__body span', paymentID).should('exist').then(() => {
-        cy.contains('div.payment-method-card__body span', paymentID).should('exist').parent().prev().find('.dc-dropdown-container').and('exist').click()
-        cy.get('#delete').should('be.visible').click()
-        cy.get('div[class="dc-modal-header"]', { withinSubject: null }).should('be.visible').and('exist').contains(`Delete ${paymentName}?`)
-        cy.get('div.dc-modal-footer button', { withinSubject: null }).first().should('be.visible').and('have.text', 'Yes, remove').click()
-        cy.get(`span:contains(${paymentID})`, { withinSubject: null }).should('not.exist')
-    })
+    cy.findByText(paymentID).should('exist').parent().prev().find('.dc-dropdown-container').and('exist').click()
+    cy.get('#delete').should('be.visible').click()
+    cy.findByText(`Delete ${paymentName}?`).should('be.visible')
+    cy.findByRole('button', { name: 'Yes, remove' }).should('be.visible').click()
+    cy.findByText(paymentID).should('not.exist')
 }
 
 function generateAccountNumberString(length) {

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -1,5 +1,5 @@
 import '@testing-library/cypress/add-commands'
-import { navigateToDerivP2P, closeNotificationHeader } from '../P2P/support/common'
+import '../../../support/p2p'
 
 let paymentMethod = null
 let paymentName = null
@@ -37,9 +37,9 @@ describe("QATEST-2839 - My Profile page - Delete Payment Method", () => {
     })
 
     it('Should be able to delete the existing payment method in responsive mode.', () => {
-        navigateToDerivP2P()
+        cy.c_navigateToDerivP2P()
         cy.findByText('Deriv P2P').should('exist')
-        closeNotificationHeader()
+        cy.c_closeNotificationHeader()
         navigateToTab('My profile')
         cy.findByText('Available Deriv P2P balance').should('be.visible')
         cy.findByText('Payment methods').should('be.visible').click()

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -13,14 +13,11 @@ function deletePaymentMethod() {
     cy.get('div.payment-method-card__body span').each(($span, index) => {
         const value = $span.text().trim()
 
-        if (index === 0 && value !== '' && !paymentName) {
+        if ((index === 0 || index === 1) && value !== '' && !paymentName) {
             paymentName = value
             return
         }
-        else if (index === 1 && value !== '' && !paymentName) {
-            paymentName = value
-            return
-        }
+        
         if (value !== '') {
             paymentID = $span.first().text().trim()
             if (paymentName && paymentID) {

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -1,5 +1,4 @@
 import '@testing-library/cypress/add-commands'
-import '../../../support/p2p'
 
 let paymentMethod = null
 let paymentName = null

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -12,20 +12,18 @@ function navigateToTab(tabName) {
 function deletePaymentMethod() {
     cy.get('div.payment-method-card__body span').each(($span, index) => {
         const value = $span.text().trim()
-
         if ((index === 0 || index === 1) && value !== '' && !paymentName) {
             paymentName = value
             return
         }
-        
         if (value !== '') {
-            paymentID = $span.first().text().trim()
-            if (paymentName && paymentID) {
+            paymentID = $span.text().trim()
+            if (paymentName && paymentName != '' && paymentID) {
                 cy.findAllByTestId('dt_dropdown_display').first().click()
                 cy.get('#delete').should('be.visible').click()
                 cy.get('div[class="dc-modal-header"]', { withinSubject: null }).should('be.visible').and('exist').contains(`Delete ${paymentName}?`)
-                cy.get('div.dc-modal-footer button', { withinSubject: null}).first().should('be.visible').and('have.text', 'Yes, remove').click()
-                cy.findByText(paymentID).should('not.visible')
+                cy.get('div.dc-modal-footer button', { withinSubject: null }).first().should('be.visible').and('have.text', 'Yes, remove').click()
+                cy.get(`span:contains(${paymentID})`, { withinSubject: null }).should('not.exist')
             }
             return false
         }

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -1,0 +1,51 @@
+import '@testing-library/cypress/add-commands'
+import { navigateToDerivP2P, closeNotificationHeader } from '../P2P/support/common'
+
+let paymentMethod = null
+let paymentName = null
+
+function navigateToTab(tabName) {
+    cy.findByText(tabName).click()
+}
+
+function deletePaymentMethod() {
+    cy.get('div.payment-method-card__body span').each(($span, index) => {
+        const value = $span.text().trim();
+        if (value !== '') {
+            paymentName = value;
+            cy.log("Payment Name - " + paymentName);
+            cy.findAllByTestId('dt_dropdown_display').first().click();
+            cy.get('#delete').should('be.visible').click();
+            cy.get('div[class="dc-modal-header"]', { withinSubject: null }).should('be.visible').and('exist').contains(`Delete ${paymentName}?`);
+            cy.get('div.dc-modal-footer button', { withinSubject: null}).first().should('be.visible').and('have.text', 'Yes, remove').click()
+            cy.findByText(paymentName).should('not.visible')
+            return false
+        }
+    })
+}
+
+describe("QATEST-2839 - My Profile page - Delete Payment Method", () => {
+    beforeEach(() => {
+        cy.c_login()
+        cy.c_visitResponsive('/appstore/traders-hub', 'small')
+    })
+
+    it('Should be able to delete the existing payment method in responsive mode.', () => {
+        navigateToDerivP2P() //Navigation to P2P Handler
+        cy.findByText('Deriv P2P').should('exist')
+        closeNotificationHeader()
+        navigateToTab('My profile')
+        cy.findByText('Available Deriv P2P balance').should('be.visible') //verifes from a page text after navigating to my profile tab
+        cy.findByText('Payment methods').should('be.visible').click()
+        cy.findByText('Payment methods').should('be.visible') //verifies that Payment methods heading page is visible after clicking on Payment Methods
+        // Get first payment type available on the screen
+        cy.get('span.payment-methods-list__list-header').first().invoke('text').then((value) => {
+            paymentMethod = value.trim() //Will only get either of the three: Bank Transfers, E-wallets, Others
+            cy.log("Payment type available: " + paymentMethod)
+            cy.contains('div.payment-methods-list__list-container span', paymentMethod).next().within(() => {
+                deletePaymentMethod()
+            })
+            
+        })
+    })
+})

--- a/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
@@ -1,36 +1,7 @@
 import '@testing-library/cypress/add-commands'
+import {navigateToDerivP2P, closeNotificationHeader} from '../P2P/support/common'
 
 let paymentMethod = null
-
-function navigateToDerivP2P() {
-    cy.get('#dt_mobile_drawer_toggle').should('be.visible').click()
-    cy.findByRole('heading', { name: 'Cashier' }).should('be.visible').click()
-    cy.findByRole('link', { name: 'Deriv P2P' }).should('be.visible').click()
-    cy.findByRole('heading', { name: 'For your safety:' }).should('be.visible').then(($title) => {
-        if ($title.is(':visible')) {
-            cy.get('.dc-checkbox__box').should('be.visible').click()
-        }
-    })
-    cy.findByRole('button', { name: 'Confirm' }).should('be.visible').click()
-}
-
-function closeNotificationHeader() {
-    cy.document().then(doc => {
-        let notification = doc.querySelector('.notification__header')
-        if (notification) {
-            cy.log('Notification header appeared')
-            cy.get('.notification__text-body').invoke('text').then((text) => {
-                cy.log(text)
-            })
-            cy.findByRole('button', { name: 'Close' }).should('be.visible').click().and('not.exist')
-            notification = null
-            cy.then(() => {closeNotificationHeader()})
-        }
-        else {
-            cy.log('Notification header did not appear')
-        }
-    })
-}
 
 function savePaymentDetailsAndVerify(accountNumberString) {
     cy.findByRole('button', { name: 'Save changes' }).should('not.be.disabled').click()

--- a/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
@@ -1,5 +1,4 @@
 import '@testing-library/cypress/add-commands'
-import '../../../support/p2p'
 
 let paymentMethod = null
 

--- a/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
@@ -1,5 +1,5 @@
 import '@testing-library/cypress/add-commands'
-import {navigateToDerivP2P, closeNotificationHeader} from '../P2P/support/common'
+import '../../../support/p2p'
 
 let paymentMethod = null
 
@@ -62,9 +62,9 @@ describe("QATEST-2831 - My Profile page - Edit Payment Method", () => {
     })
 
     it('Should be able to edit the existing payment method in responsive mode.', () => {
-        navigateToDerivP2P() //Navigation to P2P Handler
+        cy.c_navigateToDerivP2P() //Navigation to P2P Handler
         cy.findByText('Deriv P2P').should('exist')
-        closeNotificationHeader()
+        cy.c_closeNotificationHeader()
         navigateToTab('My profile')
         cy.findByText('Available Deriv P2P balance').should('be.visible') //verifes from a page text after navigating to my profile tab
         cy.findByText('Payment methods').should('be.visible').click()

--- a/cypress/e2e/wip/P2P/support/common.js
+++ b/cypress/e2e/wip/P2P/support/common.js
@@ -1,0 +1,31 @@
+import '@testing-library/cypress/add-commands'
+
+export function navigateToDerivP2P() {
+    cy.get('#dt_mobile_drawer_toggle').should('be.visible').click()
+    cy.findByRole('heading', { name: 'Cashier' }).should('be.visible').click()
+    cy.findByRole('link', { name: 'Deriv P2P' }).should('be.visible').click()
+    cy.findByRole('heading', { name: 'For your safety:' }).should('be.visible').then(($title) => {
+        if ($title.is(':visible')) {
+            cy.get('.dc-checkbox__box').should('be.visible').click()
+        }
+    })
+    cy.findByRole('button', { name: 'Confirm' }).should('be.visible').click()
+}
+
+export function closeNotificationHeader() {
+    cy.document().then(doc => {
+        let notification = doc.querySelector('.notification__header')
+        if (notification) {
+            cy.log('Notification header appeared')
+            cy.get('.notification__text-body').invoke('text').then((text) => {
+                cy.log(text)
+            })
+            cy.findByRole('button', { name: 'Close' }).should('be.visible').click().and('not.exist')
+            notification = null
+            cy.then(() => {closeNotificationHeader()})
+        }
+        else {
+            cy.log('Notification header did not appear')
+        }
+    })
+}

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,5 +1,6 @@
 import './commands'
 import './dtrader'
+import './p2p'
 require('cypress-xpath')
 
 const { getLoginToken } = require("./common")

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,6 +1,7 @@
 import './commands'
 import './dtrader'
 import './p2p'
+
 require('cypress-xpath')
 
 const { getLoginToken } = require("./common")

--- a/cypress/support/p2p.js
+++ b/cypress/support/p2p.js
@@ -1,6 +1,4 @@
-import '@testing-library/cypress/add-commands'
-
-export function navigateToDerivP2P() {
+Cypress.Commands.add('c_navigateToDerivP2P', () => {
     cy.get('#dt_mobile_drawer_toggle').should('be.visible').click()
     cy.findByRole('heading', { name: 'Cashier' }).should('be.visible').click()
     cy.findByRole('link', { name: 'Deriv P2P' }).should('be.visible').click()
@@ -10,9 +8,9 @@ export function navigateToDerivP2P() {
         }
     })
     cy.findByRole('button', { name: 'Confirm' }).should('be.visible').click()
-}
+})
 
-export function closeNotificationHeader() {
+Cypress.Commands.add('c_closeNotificationHeader', () => {
     cy.document().then(doc => {
         let notification = doc.querySelector('.notification__header')
         if (notification) {
@@ -22,10 +20,10 @@ export function closeNotificationHeader() {
             })
             cy.findByRole('button', { name: 'Close' }).should('be.visible').click().and('not.exist')
             notification = null
-            cy.then(() => {closeNotificationHeader()})
+            cy.then(() => { cy.c_closeNotificationHeader() })
         }
         else {
             cy.log('Notification header did not appear')
         }
     })
-}
+})


### PR DESCRIPTION
### Cypress test for deletePaymentMethods, refactoring of editPaymentMethods and common.js for reusable functions

This test covers the deletion of a payment method for P2P from the user's profile page. 

I have also added a common.js file which includes common functions that I have used in both editPaymentMethods and deletePaymentMethods spec files. 

I have refactored the editPaymentMethods spec file to support the use of functions in common.js. 