### PR TITLE
[1 Line Fix] - Support for 5 digit 1 USD rate in Floating rate spec file

### DIFF
--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -42,7 +42,7 @@ Cypress.Commands.add('c_verifyExchangeRate', (rate) => {
   rateCalculation = rate * 0.01
   calculatedValue = rateCalculation * marketRate + marketRate
   regexPattern = new RegExp(
-    `Your rate is = ${calculatedValue.toFixed(6).slice(0, -1)}\\d NZD`
+    `Your rate is = ${calculatedValue.toFixed(6).slice(0, -1)}\\d? NZD`
   )
   cy.get('.floating-rate__hint').invoke('text').should('match', regexPattern)
 })


### PR DESCRIPTION
The digit in floating rate can also come as 5 decimal places (this is not common) hence it came up while running the test in v2. 

<img width="397" alt="image" src="https://github.com/deriv-com/e2e-deriv-app/assets/152943428/b40c6602-43cf-4303-b92a-67a5229c2f0f">

<img width="875" alt="image" src="https://github.com/deriv-com/e2e-deriv-app/assets/152943428/1b352a47-4dc2-4e8e-a036-e74e6b9712a9">
