### PR TITLE
Fix for P2P Cron March 29

### DIFF
--- a/cypress/e2e/wip/P2P/addAdditionalPaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/addAdditionalPaymentMethods.cy.js
@@ -8,11 +8,13 @@ let additionalPaymentID = generateAccountNumberString(12)
 
 describe('QATEST-2811 - My profile page - User with existing payment method add new payment method', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
     cy.c_login()
-    cy.c_visitResponsive('/cashier/p2p', 'small')
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 
   it('Should be able to add additional payment method in responsive mode.', () => {
+    cy.c_navigateToDerivP2P()
     cy.c_closeSafetyInstructions()
     cy.findByText('Deriv P2P').should('exist')
     cy.c_closeNotificationHeader()

--- a/cypress/e2e/wip/P2P/addFirstPaymentMethod.cy.js
+++ b/cypress/e2e/wip/P2P/addFirstPaymentMethod.cy.js
@@ -6,11 +6,13 @@ let paymentID = generateAccountNumberString(12)
 
 describe('QATEST-2821 - My Profile page : User add their first payment method', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
     cy.c_login()
-    cy.c_visitResponsive('/cashier/p2p', 'small')
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 
   it('Should be able to add first payment method in responsive mode.', () => {
+    cy.c_navigateToDerivP2P()
     cy.c_closeSafetyInstructions()
     cy.findByText('Deriv P2P').should('exist')
     cy.c_closeNotificationHeader()

--- a/cypress/e2e/wip/P2P/blockUnblockAdvertiser.cy.js
+++ b/cypress/e2e/wip/P2P/blockUnblockAdvertiser.cy.js
@@ -161,12 +161,14 @@ function unblockedAdvertiserValidation(advertNickname) {
 
 describe('QATEST-2871 - Block and unblock user from advertisers profile page', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
     cy.clearAllSessionStorage()
     cy.c_login()
-    cy.c_visitResponsive('/cashier/p2p', 'small')
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 
   it('Should be able to block and unblock the advertiser from profile page in responsive mode.', () => {
+    cy.c_navigateToDerivP2P()
     cy.c_closeSafetyInstructions()
     cy.findByText('Deriv P2P').should('exist')
     cy.c_closeNotificationHeader()

--- a/cypress/e2e/wip/P2P/createAdBuy.cy.js
+++ b/cypress/e2e/wip/P2P/createAdBuy.cy.js
@@ -2,6 +2,7 @@ import '@testing-library/cypress/add-commands'
 
 describe('QATEST-2414 - Create a Buy type Advert : Floating Rate', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
     cy.c_login({ user: 'p2pFloating' })
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })

--- a/cypress/e2e/wip/P2P/createAdBuyFixedRate.cy.js
+++ b/cypress/e2e/wip/P2P/createAdBuyFixedRate.cy.js
@@ -15,12 +15,14 @@ function verifyAdOnMyAdsScreen(fiatCurrency, localCurrency) {
 
 describe('QATEST-2403 - Create a Buy type Advert - Fixed Rate', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
     cy.clearAllSessionStorage()
     cy.c_login({ user: 'p2pFixedRate' })
-    cy.c_visitResponsive('/cashier/p2p', 'small')
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 
   it('Should be able to create buy type advert and verify all fields and messages for fixed rate.', () => {
+    cy.c_navigateToDerivP2P()
     cy.c_closeSafetyInstructions()
     cy.findByText('Deriv P2P').should('exist')
     cy.c_closeNotificationHeader()

--- a/cypress/e2e/wip/P2P/createAdSellFixedRate.cy.js
+++ b/cypress/e2e/wip/P2P/createAdSellFixedRate.cy.js
@@ -17,11 +17,13 @@ function verifyAdOnMyAdsScreen(adType, fiatCurrency, localCurrency) {
 }
 describe('QATEST-2425 - Create a Sell type Advert - Fixed Rate', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
     cy.clearAllSessionStorage()
     cy.c_login({ user: 'p2pFixedRate' })
-    cy.c_visitResponsive('/cashier/p2p', 'small')
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
   it('Should be able to create sell type advert and verify all fields and messages for fixed rate.', () => {
+    cy.c_navigateToDerivP2P()
     cy.c_closeSafetyInstructions()
     cy.findByText('Deriv P2P').should('exist')
     cy.c_closeNotificationHeader()

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -6,11 +6,13 @@ let paymentID = generateAccountNumberString(12)
 
 describe('QATEST-2839 - My Profile page - Delete Payment Method', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
     cy.c_login()
-    cy.c_visitResponsive('/cashier/p2p', 'small')
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 
   it('Should be able to delete the existing payment method in responsive mode.', () => {
+    cy.c_navigateToDerivP2P()
     cy.c_closeSafetyInstructions()
     cy.findByText('Deriv P2P').should('exist')
     cy.c_closeNotificationHeader()

--- a/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
@@ -36,11 +36,13 @@ function editPaymentMethod() {
 
 describe('QATEST-2831 - My Profile page - Edit Payment Method', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
     cy.c_login()
-    cy.c_visitResponsive('/cashier/p2p', 'small')
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 
   it('Should be able to edit the existing payment method in responsive mode.', () => {
+    cy.c_navigateToDerivP2P()
     cy.c_closeSafetyInstructions()
     cy.findByText('Deriv P2P').should('exist')
     cy.c_closeNotificationHeader()


### PR DESCRIPTION
Cron job failure: 
https://cloud.cypress.io/projects/9szghx/runs/7/overview?roarHideRunsWithDiffGroupsAndTags=1

Issue traced: 'Safety' banner gets stored in local storage of browser so that it is not displayed to the user everytime. 

resolution: 
1. cy.clearAllLocalStorage()
2. brought back navigation to P2P so that it can be naturally tested like user navigates to P2P. 

Issue discussion: https://deriv-group.slack.com/archives/C0530AJQL3B/p1711681077429859