### PR TITLE
Check for blockly to be loaded

### DIFF
--- a/cypress/e2e/wip/dbot/pageobjects/common.js
+++ b/cypress/e2e/wip/dbot/pageobjects/common.js
@@ -112,7 +112,7 @@ class Common {
   }
 
   blockDashboardLoad = () => {
-    cy.get('.bot-dashboard.bot').should('be.visible').wait(2000)
+    cy.get('.bot-dashboard.bot').should('be.visible')
   }
 
   /**

--- a/cypress/e2e/wip/dbot/pageobjects/common.js
+++ b/cypress/e2e/wip/dbot/pageobjects/common.js
@@ -111,6 +111,10 @@ class Common {
     this.blocklyDurationValue.type('2')
   }
 
+  blockDashboardLoad = () => {
+    cy.get('.bot-dashboard.bot').should('be.visible').wait(2000)
+  }
+
   /**
    * Skip the tour
    */

--- a/cypress/e2e/wip/dbot/sanity-tests/QuickStrategies.cy.js
+++ b/cypress/e2e/wip/dbot/sanity-tests/QuickStrategies.cy.js
@@ -15,6 +15,7 @@ describe('QATEST-4212: Verify Quick Strategy from bot builder page', () => {
     cy.c_login()
     cy.c_visitResponsive('/appstore/traders-hub', 'large')
     tradersHub.openBotButton.click()
+    common.blockDashboardLoad()
     common.skipTour()
     common.switchToDemo()
     botBuilder.openBotBuilderTab()

--- a/cypress/e2e/wip/dbot/sanity-tests/RunMartingaleOld.cy.js
+++ b/cypress/e2e/wip/dbot/sanity-tests/RunMartingaleOld.cy.js
@@ -22,6 +22,7 @@ describe('QATEST-99420: Import and run custom strategy', () => {
 
   it('Run Martingale Old Strategy', () => {
     botDashboard.importStrategy('MartingaleOld')
+    common.blockDashboardLoad()
     common.skipTour()
 
     //Enter Expected profit, expected Loss, and Trade Amount

--- a/cypress/e2e/wip/dbot/sanity-tests/RunTimelyBalance.cy.js
+++ b/cypress/e2e/wip/dbot/sanity-tests/RunTimelyBalance.cy.js
@@ -24,6 +24,7 @@ describe('QATEST-99419: Import and run custom strategy', () => {
 
   it('Run Timely Balance Strategy', () => {
     botDashboard.importStrategy('TimelyBalance')
+    common.blockDashboardLoad()
     common.skipTour()
 
     common.accountBalance.then(($el) => {


### PR DESCRIPTION
Desc: Adding a wait until the block dashboard components are loaded upon opening dbot/uploading strategy. 
**No cards created as its a small fix
