### PR TITLE
Fix failures

### DIFF
--- a/cypress/e2e/wip/Tradershub/accountSignupDIEL(CR+MF).cy.js
+++ b/cypress/e2e/wip/Tradershub/accountSignupDIEL(CR+MF).cy.js
@@ -1,8 +1,6 @@
 import '@testing-library/cypress/add-commands'
 import { generateEpoch } from '../../../support/helper/utility'
 
-const regulationText = '.regulators-switcher__switch div.item.is-selected'
-
 describe('QATEST-5554: Verify DIEL Signup flow - CR + MF', () => {
   const signUpEmail = `sanity${generateEpoch()}diel@deriv.com`
   let country = Cypress.env('countries').ZA
@@ -15,10 +13,10 @@ describe('QATEST-5554: Verify DIEL Signup flow - CR + MF', () => {
   it('Verify I can signup for a DIEL demo and real account', () => {
     Cypress.env('citizenship', country)
     cy.c_demoAccountSignup(country, signUpEmail)
+    cy.c_completeTradersHubTour(true)
     cy.c_checkTradersHubHomePage()
-    cy.findByTestId('dt_dropdown_display').click()
-    cy.get('#real').click()
-    cy.get(regulationText).should('have.text', 'Non-EU')
+    cy.c_switchToReal()
+    cy.findByText('Non-EU').parent().should('have.class', 'is-selected')
     cy.findByRole('button', { name: 'Get a Deriv account' }).click()
     cy.c_generateRandomName().then((firstName) => {
       cy.c_personalDetails(firstName, 'IDV', country, nationalIDNum, taxIDNum)
@@ -29,8 +27,8 @@ describe('QATEST-5554: Verify DIEL Signup flow - CR + MF', () => {
     cy.c_addressDetails()
     cy.c_completeFatcaDeclarationAgreement()
     cy.c_addAccount()
-    cy.findByText('EU', { exact: true }).click()
-    cy.get(regulationText).should('have.text', 'EU')
+    cy.findByText('EU').click()
+    cy.findByText('EU').parent().should('have.class', 'is-selected')
     cy.findByRole('button', { name: 'Get a Deriv account' }).click()
     cy.findByText('US Dollar').click()
     cy.findByRole('button', { name: 'Next' }).click()

--- a/cypress/e2e/wip/Tradershub/accountSignupDIEL(MF+CR).cy.js
+++ b/cypress/e2e/wip/Tradershub/accountSignupDIEL(MF+CR).cy.js
@@ -14,13 +14,13 @@ describe('QATEST-6211: Verify DIEL Signup flow - MF + CR', () => {
     cy.c_setEndpoint(signUpEmail)
   })
   it('Verify I can signup for a DIEL demo and real account', () => {
-    Cypress.env('citizenship', Cypress.env('dielCountry'))
+    Cypress.env('citizenship', country)
     cy.c_demoAccountSignup(country, signUpEmail)
+    cy.c_completeTradersHubTour(true)
     cy.c_checkTradersHubHomePage()
-    cy.findByTestId('dt_dropdown_display').click()
-    cy.get('#real').click()
+    cy.c_switchToReal()
     cy.findByText('EU', { exact: true }).click()
-    cy.get(regulationText).should('have.text', 'EU')
+    cy.findByText('EU').parent().should('have.class', 'is-selected')
     cy.findByRole('button', { name: 'Get a Deriv account' }).click()
     cy.c_generateRandomName().then((firstName) => {
       cy.c_personalDetails(
@@ -38,7 +38,7 @@ describe('QATEST-6211: Verify DIEL Signup flow - MF + CR', () => {
     cy.c_completeFatcaDeclarationAgreement()
     cy.c_addAccountMF()
     cy.findByText('Non-EU', { exact: true }).click()
-    cy.get(regulationText).should('have.text', 'Non-EU')
+    cy.findByText('Non-EU').parent().should('have.class', 'is-selected')
     cy.findByRole('button', { name: 'Get a Deriv account' }).click()
     cy.findByText('US Dollar').click()
     cy.findByRole('button', { name: 'Next' }).click()

--- a/cypress/e2e/wip/Tradershub/accountSignupMF.cy.js
+++ b/cypress/e2e/wip/Tradershub/accountSignupMF.cy.js
@@ -12,6 +12,7 @@ describe('QATEST-5569: Verify MF Signup flow', () => {
     cy.c_setEndpoint(signUpEmail)
   })
   it('Verify I can signup for an MF demo and real account', () => {
+    Cypress.env('citizenship', country)
     cy.c_demoAccountSignup(country, signUpEmail)
     cy.c_generateRandomName().then((firstName) => {
       cy.c_personalDetails(

--- a/cypress/e2e/wip/Tradershub/addDemoFinancialExistingMT5Pwd.cy.js
+++ b/cypress/e2e/wip/Tradershub/addDemoFinancialExistingMT5Pwd.cy.js
@@ -11,6 +11,7 @@ describe('QATEST-5724: CFDs - Create a demo Financial account using existing MT5
 
   it('Verify I can add a demo financial account using exisiting MT5 derieved account password', () => {
     cy.c_demoAccountSignup(country, signUpEmail)
+    cy.c_completeTradersHubTour()
     cy.c_checkTradersHubHomePage()
     cy.findAllByRole('button', { name: 'Get' }).first().click()
     cy.findByText('Create a Deriv MT5 password').should('be.visible')

--- a/cypress/e2e/wip/Tradershub/addSiblingsAccounts.cy.js
+++ b/cypress/e2e/wip/Tradershub/addSiblingsAccounts.cy.js
@@ -1,5 +1,5 @@
 import '@testing-library/cypress/add-commands'
-import { generateEpoch } from '../../../support/tradersHub'
+import { generateEpoch } from '../../../support/helper/utility'
 
 function createSiblingAcct(acctCount) {
   cy.findByTestId('dt_currency-switcher__arrow').click()
@@ -31,7 +31,7 @@ describe('QATEST-5797, QATEST-5820 - Add siblings accounts', () => {
   })
 
   it('Create siblings accounts from USD account ', () => {
-    cy.c_demoAccountSignup(epoch, country)
+    cy.c_demoAccountSignup(country, signUpMail)
     cy.c_switchToReal()
     cy.findByRole('button', { name: 'Next' }).click()
     cy.findByRole('button', { name: 'OK' }).click()

--- a/cypress/e2e/wip/Tradershub/changeAccountCurrency.cy.js
+++ b/cypress/e2e/wip/Tradershub/changeAccountCurrency.cy.js
@@ -1,5 +1,5 @@
 import '@testing-library/cypress/add-commands'
-import { generateEpoch } from '../../../support/tradersHub'
+import { generateEpoch } from '../../../support/helper/utility'
 
 describe('QATEST-5918: Verify Change currency functionality for the account which has no balance', () => {
   const signUpEmail = `sanity${generateEpoch()}crypto@deriv.com`
@@ -18,6 +18,7 @@ describe('QATEST-5918: Verify Change currency functionality for the account whic
   })
   it('Should be able to change currency', () => {
     cy.c_demoAccountSignup(country, signUpEmail)
+    cy.c_completeTradersHubTour()
     cy.c_switchToReal()
     cy.findByRole('button', { name: 'Get a Deriv account' }).click()
     cy.c_generateRandomName().then((firstName) => {

--- a/cypress/e2e/wip/Tradershub/depositAccountSwitcher.cy.js
+++ b/cypress/e2e/wip/Tradershub/depositAccountSwitcher.cy.js
@@ -4,14 +4,13 @@ describe('QATEST 54262 - Verify deposit functionality from account switcher', ()
   it('Should validate the deposit button from account switcher in desktop', () => {
     cy.c_login()
     cy.c_visitResponsive('/appstore/traders-hub', 'large')
-    cy.c_checkTradersHubhomePage()
-    cy.findByTestId('dt_dropdown_display').click()
-    cy.get('#real').click()
+    cy.c_checkTradersHubHomePage()
+    cy.c_switchToReal()
     cy.c_closeNotificationHeader()
     cy.findByRole('button', { name: 'Deposit' }).click()
-    cy.url().should('include', '/cashier/deposit')
     cy.findByText('Deposit via bank wire, credit card, and e-wallet').should(
       'be.visible'
     )
+    cy.url().should('include', '/cashier/deposit')
   })
 })

--- a/cypress/e2e/wip/Tradershub/mt5DerivedDemoSignup.cy.js
+++ b/cypress/e2e/wip/Tradershub/mt5DerivedDemoSignup.cy.js
@@ -10,6 +10,7 @@ describe('QATEST-5695: Create a Derived Demo CFD account', () => {
   })
   it('Verify I can signup for a demo derived CFD account', () => {
     cy.c_demoAccountSignup(country, signUpEmail)
+    cy.c_completeTradersHubTour()
     cy.c_checkTradersHubHomePage()
     cy.findAllByRole('button', { name: 'Get' }).first().click()
     cy.findByText('Create a Deriv MT5 password').should('be.visible')

--- a/cypress/e2e/wip/Tradershub/mt5DerivedSVGRealAccount.cy.js
+++ b/cypress/e2e/wip/Tradershub/mt5DerivedSVGRealAccount.cy.js
@@ -12,9 +12,9 @@ describe('QATEST-5972: Create a Derived SVG account', () => {
   })
   it('Verify I can signup for a real derived SVG CFD account', () => {
     cy.c_demoAccountSignup(country, signUpEmail)
+    cy.c_completeTradersHubTour()
     cy.c_checkTradersHubHomePage()
-    cy.findByTestId('dt_dropdown_display').click()
-    cy.get('#real').click()
+    cy.c_switchToReal()
     //Create real account
     cy.findByRole('button', { name: 'Get a Deriv account' }).click()
     cy.c_generateRandomName().then((firstName) => {

--- a/cypress/e2e/wip/Tradershub/mt5FinancialDemoSignup.cy.js
+++ b/cypress/e2e/wip/Tradershub/mt5FinancialDemoSignup.cy.js
@@ -6,10 +6,11 @@ describe('QATEST-5699: Create a Financial Demo CFD account', () => {
   let country = Cypress.env('countries').CO
 
   beforeEach(() => {
-    cy.c_setEndpoint(signUpMail)
+    cy.c_setEndpoint(signUpEmail)
   })
   it('Verify I can signup for a demo financial CFD account', () => {
     cy.c_demoAccountSignup(country, signUpEmail)
+    cy.c_completeTradersHubTour()
     cy.c_checkTradersHubHomePage()
     cy.findAllByRole('button', { name: 'Get' }).eq(1).click()
     cy.findByText('Create a Deriv MT5 password').should('be.visible')

--- a/cypress/e2e/wip/Tradershub/mt5FinancialSVGRealAccount.cy.js
+++ b/cypress/e2e/wip/Tradershub/mt5FinancialSVGRealAccount.cy.js
@@ -12,9 +12,9 @@ describe('QATEST-6000: Create a Financial SVG account', () => {
   })
   it('Verify I can signup for a real Financial SVG CFD account', () => {
     cy.c_demoAccountSignup(country, signUpEmail)
+    cy.c_completeTradersHubTour()
     cy.c_checkTradersHubHomePage()
-    cy.findByTestId('dt_dropdown_display').click()
-    cy.get('#real').click()
+    cy.c_switchToReal()
     //Create real account
     cy.findByRole('button', { name: 'Get a Deriv account' }).click()
     cy.c_generateRandomName().then((firstName) => {

--- a/cypress/e2e/wip/Tradershub/personalDetailsPopUpValidation.cy.js
+++ b/cypress/e2e/wip/Tradershub/personalDetailsPopUpValidation.cy.js
@@ -1,5 +1,5 @@
 import '@testing-library/cypress/add-commands'
-import { generateEpoch } from '../../../support/tradersHub'
+import { generateEpoch } from '../../../support/helper/utility'
 
 describe('QATEST-24444 - Verify the user is able to close the personal details pop up during sign up', () => {
   const signUpMail = `sanity${generateEpoch()}account@deriv.com`
@@ -11,8 +11,8 @@ describe('QATEST-24444 - Verify the user is able to close the personal details p
 
   it('Should validate the pop up functionality when user closes the personal details section', () => {
     cy.c_demoAccountSignup(country, signUpMail)
-    cy.c_switchToReal()
     cy.c_completeTradersHubTour()
+    cy.c_switchToReal()
     cy.findByRole('button', { name: 'Get a Deriv account' }).click({
       force: true,
     })

--- a/cypress/e2e/wip/Tradershub/platformNavOptandMult.cy.js
+++ b/cypress/e2e/wip/Tradershub/platformNavOptandMult.cy.js
@@ -4,8 +4,8 @@ describe('QATEST-5948: Verify platforms navigations on Options and Multipliers',
   it('Should navigate to correct platform on clicking Open button', () => {
     cy.c_login()
     cy.c_visitResponsive('/appstore/traders-hub', 'large')
-    const derivAppProdUrl = Cypress.env('prodURL')
-    const derivAppStagingUrl = Cypress.env('stagingUrl')
+    const derivAppProdUrl = `${Cypress.env('prodURL')}?chart_type=area&interval=1t&symbol=1HZ100V&trade_type=accumulator`
+    const derivAppStagingUrl = `${Cypress.env('stagingUrl')}?chart_type=area&interval=1t&symbol=1HZ100V&trade_type=accumulator`
     const bBotStagingUrl = Cypress.env('binaryBotUrl').staging
     const bBotProdUrl = Cypress.env('binaryBotUrl').prod
     const smartTraderStagingUrl = Cypress.env('smartTraderUrl').staging

--- a/cypress/e2e/wip/Tradershub/platformNavOptandMult.cy.js
+++ b/cypress/e2e/wip/Tradershub/platformNavOptandMult.cy.js
@@ -4,8 +4,12 @@ describe('QATEST-5948: Verify platforms navigations on Options and Multipliers',
   it('Should navigate to correct platform on clicking Open button', () => {
     cy.c_login()
     cy.c_visitResponsive('/appstore/traders-hub', 'large')
-    const derivAppProdUrl = `${Cypress.env('prodURL')}?chart_type=area&interval=1t&symbol=1HZ100V&trade_type=accumulator`
-    const derivAppStagingUrl = `${Cypress.env('stagingUrl')}?chart_type=area&interval=1t&symbol=1HZ100V&trade_type=accumulator`
+    const derivAppProdUrl = new RegExp(
+      `${Cypress._.escapeRegExp(Cypress.env('prodURL'))}\\?chart_type=[a-z]+\\&interval=[0-9]+[a-z]\\&symbol=[0-9a-zA-Z]+\\&trade_type=[a-z]+`
+    )
+    const derivAppStagingUrl = new RegExp(
+      `${Cypress._.escapeRegExp(Cypress.env('stagingUrl'))}\\?chart_type=[a-z]+\\&interval=[0-9]+[a-z]\\&symbol=[0-9a-zA-Z]+\\&trade_type=[a-z]+`
+    )
     const bBotStagingUrl = Cypress.env('binaryBotUrl').staging
     const bBotProdUrl = Cypress.env('binaryBotUrl').prod
     const smartTraderStagingUrl = Cypress.env('smartTraderUrl').staging
@@ -17,8 +21,8 @@ describe('QATEST-5948: Verify platforms navigations on Options and Multipliers',
     cy.findAllByRole('button', { name: 'Open' }).first().click({ force: true })
     cy.get('flt-glass-pane', { timeout: 15000 }).should('be.visible')
     if (Cypress.config().baseUrl.includes('staging'))
-      cy.url().should('eql', derivAppStagingUrl)
-    else cy.url().should('eql', derivAppProdUrl)
+      cy.url().should('match', derivAppStagingUrl)
+    else cy.url().should('match', derivAppProdUrl)
 
     //Open DBot
     cy.c_visitResponsive('/appstore/traders-hub', 'large')

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -316,6 +316,7 @@ Cypress.Commands.add('c_closeNotificationHeader', () => {
         })
       cy.findAllByRole('button', { name: 'Close' })
         .first()
+        .scrollIntoView()
         .should('be.visible')
         .click()
         .and('not.exist')

--- a/cypress/support/commands/tradersHub.js
+++ b/cypress/support/commands/tradersHub.js
@@ -25,9 +25,9 @@ Cypress.Commands.add('c_switchToDemo', () => {
     .click({ force: true })
 })
 
-Cypress.Commands.add('c_completeTradersHubTour', (diel = false) => {
+Cypress.Commands.add('c_completeTradersHubTour', (isDiel = false) => {
   cy.findByRole('button', { name: 'Next' }).click()
-  if (diel) cy.findByRole('button', { name: 'Next' }).click()
+  if (isDiel) cy.findByRole('button', { name: 'Next' }).click()
   cy.findByRole('button', { name: 'OK' }).click()
 })
 

--- a/cypress/support/commands/tradersHub.js
+++ b/cypress/support/commands/tradersHub.js
@@ -11,16 +11,23 @@ Cypress.Commands.add('c_checkTradersHubHomePage', () => {
 
 Cypress.Commands.add('c_switchToReal', () => {
   cy.findByTestId('dt_dropdown_display').click()
-  cy.get('#real').click()
+  cy.findByTestId('dt_dropdown_container')
+    .findAllByText('Real')
+    .last()
+    .click({ force: true })
 })
 
 Cypress.Commands.add('c_switchToDemo', () => {
   cy.findByTestId('dt_dropdown_display').click()
-  cy.get('#demo').click()
+  cy.findByTestId('dt_dropdown_container')
+    .findAllByText('Demo')
+    .last()
+    .click({ force: true })
 })
 
-Cypress.Commands.add('c_completeTradersHubTour', () => {
+Cypress.Commands.add('c_completeTradersHubTour', (diel = false) => {
   cy.findByRole('button', { name: 'Next' }).click()
+  if (diel) cy.findByRole('button', { name: 'Next' }).click()
   cy.findByRole('button', { name: 'OK' }).click()
 })
 
@@ -116,7 +123,9 @@ Cypress.Commands.add(
     currency = Cypress.env('accountCurrency').USD
   ) => {
     cy.findByText(currency).click()
-    cy.findByRole('button', { name: 'Next' }).click()
+    cy.findByTestId('dt_modal_footer')
+      .findByRole('button', { name: 'Next' })
+      .click()
     if (identity == 'Onfido') {
       cy.contains('Any information you provide is confidential').should(
         'be.visible'
@@ -175,8 +184,12 @@ Cypress.Commands.add(
     }
     //below check is to make sure previous button is working.
     cy.findByRole('button', { name: 'Previous' }).click()
-    cy.findByRole('button', { name: 'Next' }).click()
-    cy.findByRole('button', { name: 'Next' }).click()
+    cy.findByTestId('dt_modal_footer')
+      .findByRole('button', { name: 'Next' })
+      .click()
+    cy.findByTestId('dt_modal_footer')
+      .findByRole('button', { name: 'Next' })
+      .click()
   }
 )
 
@@ -185,7 +198,9 @@ Cypress.Commands.add('c_addressDetails', () => {
   cy.findByLabelText('Second line of address').type('myaddress 2')
   cy.findByLabelText('Town/City*').type('mycity')
   cy.findByLabelText('Postal/ZIP Code').type('1234')
-  cy.findByRole('button', { name: 'Next' }).click()
+  cy.findByTestId('dt_modal_footer')
+    .findByRole('button', { name: 'Next' })
+    .click()
 })
 
 Cypress.Commands.add('c_addAccount', () => {
@@ -262,8 +277,10 @@ Cypress.Commands.add('c_completeFatcaDeclarationAgreement', () => {
 Cypress.Commands.add('c_addAccountMF', () => {
   cy.findByRole('button', { name: 'Add account' }).should('be.disabled')
   cy.get('.dc-checkbox__box').eq(0).click()
-  cy.findByRole('button', { name: 'Add account' }).should('be.disabled')
   cy.get('.dc-checkbox__box').eq(1).click()
+  //To handle additional declaration for Spain https://app.clickup.com/t/20696747/TRAH-2864
+  if (Cypress.env('citizenship') == Cypress.env('countries').ES)
+    cy.get('.dc-checkbox__box').eq(2).click()
   cy.findByRole('button', { name: 'Add account' }).click()
   cy.findByRole('heading', { name: 'Deposit' }).should('be.visible')
   cy.findByTestId('dt_modal_close_icon').click()


### PR DESCRIPTION
1. Add scrollIntoView to `c_closeNotificationHeader`
2. Added cy.c_completeTradersHubTour() to tests
3. Updated `c_switchToReal` and `c_switchToDemo` to use testing library locators
4. Updated generateEpoch import path for some tests
5. Added additional check to handle declaration for spain (card ref: https://app.clickup.com/t/20696747/TRAH-2864)

Test Results: 6 failures left, platformNavOptandMult.cy.js is expected to fail due to Smart Trader not loading in staging. Another issue is in picking signup email. Will fix it here: https://app.clickup.com/t/20696747/FEQ-2033. 

<img width="818" alt="image" src="https://github.com/deriv-com/e2e-deriv-app/assets/132635598/156d9c3a-d33c-4b4a-a12e-93bbf0a77fe7">



