### PR TITLE
Using Standard P2P Accounts for Testing

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -60,6 +60,14 @@ module.exports = defineConfig({
         ID: process.env.E2E_LOGIN_ID_DBOT,
         PSWD: process.env.E2E_LOGIN_PSWD_DBOT
       },
+      p2pStandardAccountWithAds: {
+        ID: process.env.E2E_LOGIN_ID_P2P_STANDARDACCOUNTWITHADS,
+        PSWD: process.env.E2E_PSWD_P2P
+      },
+      p2pStandardAccountWithoutAds: {
+        ID: process.env.E2E_LOGIN_ID_P2P_STANDARDACCOUNTWITHOUTADS,
+        PSWD: process.env.E2E_PSWD_P2P
+      },
       p2pFixedRate: {
         ID: process.env.E2E_LOGIN_ID_P2P_FIXEDRATE,
         PSWD: process.env.E2E_PSWD_P2P

--- a/cypress/e2e/wip/P2P/addAdditionalPaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/addAdditionalPaymentMethods.cy.js
@@ -9,7 +9,7 @@ let additionalPaymentID = generateAccountNumberString(12)
 describe('QATEST-2811 - My profile page - User with existing payment method add new payment method', () => {
   beforeEach(() => {
     cy.clearAllLocalStorage()
-    cy.c_login()
+    cy.c_login({ user: 'p2pStandardAccountWithoutAds' })
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 

--- a/cypress/e2e/wip/P2P/addFirstPaymentMethod.cy.js
+++ b/cypress/e2e/wip/P2P/addFirstPaymentMethod.cy.js
@@ -7,7 +7,7 @@ let paymentID = generateAccountNumberString(12)
 describe('QATEST-2821 - My Profile page : User add their first payment method', () => {
   beforeEach(() => {
     cy.clearAllLocalStorage()
-    cy.c_login()
+    cy.c_login({ user: 'p2pStandardAccountWithoutAds' })
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 

--- a/cypress/e2e/wip/P2P/blockUnblockAdvertiser.cy.js
+++ b/cypress/e2e/wip/P2P/blockUnblockAdvertiser.cy.js
@@ -164,7 +164,7 @@ describe('QATEST-2871 - Block and unblock user from advertisers profile page', (
     cy.clearAllLocalStorage()
     cy.clearAllSessionStorage()
     cy.clearAllCookies()
-    cy.c_login()
+    cy.c_login({ user: 'p2pStandardAccountWithoutAds' })
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 

--- a/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/deletePaymentMethods.cy.js
@@ -7,7 +7,7 @@ let paymentID = generateAccountNumberString(12)
 describe('QATEST-2839 - My Profile page - Delete Payment Method', () => {
   beforeEach(() => {
     cy.clearAllLocalStorage()
-    cy.c_login()
+    cy.c_login({ user: 'p2pStandardAccountWithoutAds' })
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 

--- a/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
+++ b/cypress/e2e/wip/P2P/editPaymentMethods.cy.js
@@ -37,7 +37,7 @@ function editPaymentMethod() {
 describe('QATEST-2831 - My Profile page - Edit Payment Method', () => {
   beforeEach(() => {
     cy.clearAllLocalStorage()
-    cy.c_login()
+    cy.c_login({ user: 'p2pStandardAccountWithoutAds' })
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 


### PR DESCRIPTION
Initially we were using mark1 account for testing p2p, but that account is being used by others and and currency on it usually chnages its settings when users testing cards manually. 

Now, we are going to be using different account that will only be used for P2P testing in Cypress.

Script has been updated in the qa_team_automation_scripts repo for generating these accounts on QA rebuild. 

Credentials shared with @meeyun-deriv and @maliheh-deriv over LP. (name: P2P standard account for cypress)

[Incorporate existing tests to use standard accounts](https://app.clickup.com/t/86by891rd)