### PR TITLE
Add common retryable command to find an element

### DIFF
--- a/cypress/support/commands/declerations/common.d.ts
+++ b/cypress/support/commands/declerations/common.d.ts
@@ -105,6 +105,22 @@ declare global {
        * @example cy.c_loadingCheck()
        */
       c_loadingCheck(): void
+
+      /**
+       * Custom command to retry finding an element until N number of tries
+       * @param options Options for locator (Cypress locator or normal CSS locator), timeout between each try (in milliseconds), and maximum retries
+       * @example cy.c_waitUntilElementIsFound({cyLocator: () => cy.findByText('Pending action required')})
+       * @example cy.c_waitUntilElementIsFound({cyLocator: () => cy.findByText('Pending action required'), maxRetries:4})
+       * @example cy.c_waitUntilElementIsFound({cyLocator: () => cy.get(':nth-child(1) > .notification__text-container > .notification__header')})
+       * @example cy.c_waitUntilElementIsFound({locator: '.notification:nth-child(1)',maxRetries: 2})
+       */
+      c_waitUntilElementIsFound(options?: {
+        cyLocator?: string
+        locator?: string
+        retry?: number
+        maxRetries?: number
+        timeout?: number
+      }): void
     }
   }
 }


### PR DESCRIPTION
This command will reload the page and will retry to find an element until it reaches maximum number of attempts. Supports Testing Library locators, Cypress locators, and CSS locators.

Tests:
<img width="978" alt="image" src="https://github.com/deriv-com/e2e-deriv-app/assets/132635598/b97a7b35-0b38-42ae-b2a4-65bf6b773615">
![image](https://github.com/deriv-com/e2e-deriv-app/assets/132635598/3443b6b4-ce86-4511-bc9c-7d996b7969dc)
