### PR TITLE
Improving api account creation functionality

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -24,7 +24,7 @@ module.exports = defineConfig({
       on('task', {
         wsConnect() {
           // Check if there is an existing connection and close it if open
-          if (connection && connection.readyState === WebSocket.OPEN) {
+          if(connection?.readyState === WebSocket.OPEN) {
             connection.close();
             console.log('Previous connection closed');
           }

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -33,14 +33,18 @@ module.exports = defineConfig({
               throw error;
           }
       },
-      async verifyEmailTask() {
+        async verifyEmailTask() {
         try {
           const accountEmail = await verifyEmail();
           return accountEmail;
-      } catch (error) {
+        } catch (error) {
           console.error('Error creating virtual account:', error);
           throw error;
       }
+      },
+      setVerificationCode: (verificationCode) => {
+        process.env.E2E_EMAIL_VERIFICATION_CODE = verificationCode;
+        return null;
       }
       });
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,6 @@
 require("dotenv").config()
 const { defineConfig } = require("cypress")
-const {createAccountReal, createAccountVirtual} = require('./cypress/support/helper/accountCreationUtility');
+const {createAccountReal, createAccountVirtual, verifyEmail} = require('./cypress/support/helper/accountCreationUtility');
 
 //const gViewPortSize = {small: 'phone-xr', large: 'macbook-16'} //TODO Use enum
  
@@ -33,6 +33,15 @@ module.exports = defineConfig({
               throw error;
           }
       },
+      async verifyEmailTask() {
+        try {
+          const accountEmail = await verifyEmail();
+          return accountEmail;
+      } catch (error) {
+          console.error('Error creating virtual account:', error);
+          throw error;
+      }
+      }
       });
 
       return config;  // Return the config object is important for custom configurations to take effect

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -37,11 +37,11 @@ module.exports = defineConfig({
 
           api = new DerivAPI({ connection });
 
-          return null;  // Return null or consider returning a success message
+          return null;
         },
         wsDisconnect() {
           if (connection && connection.readyState === WebSocket.OPEN) {
-            connection.close();  // Close the connection if it is open
+            connection.close();
             console.log('Connection closed successfully');
           } else {
             console.log('Connection is not open or has already been closed');

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -40,7 +40,7 @@ module.exports = defineConfig({
           return null;
         },
         wsDisconnect() {
-          if (connection && connection.readyState === WebSocket.OPEN) {
+          if (connection?.readyState === WebSocket.OPEN) {
             connection.close();
             console.log('Connection closed successfully');
           } else {

--- a/cypress/e2e/api/createAccountAndLogin.cy.js
+++ b/cypress/e2e/api/createAccountAndLogin.cy.js
@@ -3,6 +3,7 @@ import '@testing-library/cypress/add-commands'
 describe('Test API account creation and Login', () => {
   beforeEach(() => {
     cy.log('<E2EOAuthUrl - beforeEach>' + Cypress.env('oAuthUrl'))
+    cy.c_visitResponsive('/')
     cy.c_createRealAccount()
     cy.c_login()
   })

--- a/cypress/e2e/api/createAccountAndLogin.cy.js
+++ b/cypress/e2e/api/createAccountAndLogin.cy.js
@@ -1,13 +1,13 @@
 import '@testing-library/cypress/add-commands'
 
-describe('Get oAuthUrl', () => {
+describe('Test API account creation and Login', () => {
   beforeEach(() => {
     cy.log('<E2EOAuthUrl - beforeEach>' + Cypress.env('oAuthUrl'))
     cy.c_createRealAccount()
     cy.c_login()
   })
 
-  it('should get the oauth url from API', () => {
-    cy.log('<E2EOAuthUrl - Test 1>' + Cypress.env('oAuthUrl'))
+  it('should set the oauth url after successful account creation and login', () => {
+    cy.log('<E2EOAuthUrl - Test >' + Cypress.env('oAuthUrl'))
   })
 })

--- a/cypress/e2e/api/createAccountAndLogin.cy.js
+++ b/cypress/e2e/api/createAccountAndLogin.cy.js
@@ -10,5 +10,10 @@ describe('Test API account creation and Login', () => {
 
   it('should set the oauth url after successful account creation and login', () => {
     cy.log('<E2EOAuthUrl - Test >' + Cypress.env('oAuthUrl'))
+    cy.log(
+      'Login: ' +
+        Cypress.env('credentials').test.masterUser.ID +
+        ' was created successfully'
+    )
   })
 })

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -437,10 +437,10 @@ Cypress.Commands.add('c_loadingCheck', () => {
 
 Cypress.Commands.add('c_createRealAccount', () => {
   // Call Verify Email and then set the Verification code in env
+  cy.task('wsConnect')
   cy.task('verifyEmailTask').then((accountEmail) => {
     cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
   })
-
   cy.task('createRealAccountTask').then((realAccountDetails) => {
     // Assuming realAccountDetails is an array where the first element is email
     const [email] = realAccountDetails
@@ -450,4 +450,5 @@ Cypress.Commands.add('c_createRealAccount', () => {
     currentCredentials.test.masterUser.ID = email
     Cypress.env('credentials', currentCredentials)
   })
+  cy.task('wsDisconnect')
 })

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -440,15 +440,12 @@ Cypress.Commands.add('c_createRealAccount', () => {
   cy.task('wsConnect')
   cy.task('verifyEmailTask').then((accountEmail) => {
     cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
-  })
-  cy.task('createRealAccountTask').then((realAccountDetails) => {
-    // Assuming realAccountDetails is an array where the first element is email
-    const { email } = realAccountDetails
-
-    // Updating Cypress environment variables with the new email
-    const currentCredentials = Cypress.env('credentials')
-    currentCredentials.test.masterUser.ID = email
-    Cypress.env('credentials', currentCredentials)
+    cy.task('createRealAccountTask').then(() => {
+      // Updating Cypress environment variables with the new email
+      const currentCredentials = Cypress.env('credentials')
+      currentCredentials.test.masterUser.ID = accountEmail
+      Cypress.env('credentials', currentCredentials)
+    })
   })
   cy.task('wsDisconnect')
 })

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -443,7 +443,7 @@ Cypress.Commands.add('c_createRealAccount', () => {
   })
   cy.task('createRealAccountTask').then((realAccountDetails) => {
     // Assuming realAccountDetails is an array where the first element is email
-    const [email] = realAccountDetails
+    const { email } = realAccountDetails
 
     // Updating Cypress environment variables with the new email
     const currentCredentials = Cypress.env('credentials')

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -372,6 +372,69 @@ Cypress.Commands.add(
 )
 
 Cypress.Commands.add(
+  'c_emailVerificationV2',
+  (requestType, accountEmail, options = {}) => {
+    const {
+      retryCount = 0,
+      maxRetries = 3,
+      baseUrl = Cypress.env('configServer') + '/events',
+    } = options
+    cy.visit(
+      `https://${Cypress.env('qaBoxLoginEmail')}:${Cypress.env(
+        'qaBoxLoginPassword'
+      )}@${baseUrl}`
+    )
+    const sentArgs = { requestType, accountEmail }
+    cy.document().then((doc) => {
+      let verification_code
+      const allRelatedEmails = Array.from(
+        doc.querySelectorAll(`a[href*="${requestType}"]`)
+      )
+      if (allRelatedEmails.length) {
+        const verificationEmail = allRelatedEmails.pop()
+        cy.wrap(verificationEmail).click()
+        cy.contains('p', `${accountEmail}`)
+          .should('be.visible')
+          .parent()
+          .children()
+          .contains('a', Cypress.config('baseUrl'))
+          .invoke('attr', 'href')
+          .then((href) => {
+            if (href) {
+              Cypress.env('verificationUrl', href)
+              const code = href.match(/code=([A-Za-z0-9]{8})/)
+              verification_code = code[1]
+              Cypress.env('emailVerificationCode', verification_code)
+              cy.log(Cypress.env('emailVerificationCode'))
+            } else {
+              cy.log('Verification link not found')
+            }
+          })
+      } else {
+        cy.log('email not found')
+      }
+    })
+
+    cy.then(() => {
+      //Retry finding email after 1 second interval
+      if (retryCount < maxRetries && !Cypress.env('verificationUrl')) {
+        cy.log(`Retrying... Attempt number: ${retryCount + 1}`)
+        cy.wait(1000)
+        cy.c_emailVerification(requestType, accountEmail, {
+          ...options,
+          retryCount: retryCount + 1,
+        })
+      }
+      if (retryCount > maxRetries) {
+        throw new Error(
+          `Signup URL extraction failed after ${maxRetries} attempts.`
+        )
+      }
+    })
+  }
+)
+
+Cypress.Commands.add(
   'c_retrieveVerificationLinkUsingMailisk',
   (account, subject, timestamp) => {
     cy.mailiskSearchInbox(Cypress.env('mailiskNamespace'), {
@@ -395,16 +458,18 @@ Cypress.Commands.add('c_loadingCheck', () => {
 Cypress.Commands.add('c_createRealAccount', () => {
   // Call Verify Email and then set the Verification code in env
   cy.task('verifyEmailTask').then((accountEmail) => {
-    cy.c_emailVerification('account_opening_new.html', accountEmail)
-  })
+    cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
+    cy.task(
+      'createRealAccountTask',
+      `${Cypress.env('emailVerificationCode')}`
+    ).then((realAccountDetails) => {
+      // Assuming realAccountDetails is an array where the first element is email
+      const [email] = realAccountDetails
 
-  cy.task('createRealAccountTask').then((realAccountDetails) => {
-    // Assuming realAccountDetails is an array where the first element is email
-    const [email] = realAccountDetails
-
-    // Updating Cypress environment variables with the new email
-    const currentCredentials = Cypress.env('credentials')
-    currentCredentials.test.masterUser.ID = email
-    Cypress.env('credentials', currentCredentials)
+      // Updating Cypress environment variables with the new email
+      const currentCredentials = Cypress.env('credentials')
+      currentCredentials.test.masterUser.ID = email
+      Cypress.env('credentials', currentCredentials)
+    })
   })
 })

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -437,20 +437,15 @@ Cypress.Commands.add('c_loadingCheck', () => {
 
 Cypress.Commands.add('c_createRealAccount', () => {
   // Call Verify Email and then set the Verification code in env
-  try {
-    cy.task('wsConnect')
-    cy.task('verifyEmailTask').then((accountEmail) => {
-      cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
-      cy.task('createRealAccountTask').then(() => {
-        // Updating Cypress environment variables with the new email
-        const currentCredentials = Cypress.env('credentials')
-        currentCredentials.test.masterUser.ID = accountEmail
-        Cypress.env('credentials', currentCredentials)
-      })
+  cy.task('wsConnect')
+  cy.task('verifyEmailTask').then((accountEmail) => {
+    cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
+    cy.task('createRealAccountTask').then(() => {
+      // Updating Cypress environment variables with the new email
+      const currentCredentials = Cypress.env('credentials')
+      currentCredentials.test.masterUser.ID = accountEmail
+      Cypress.env('credentials', currentCredentials)
     })
-  } catch (e) {
-    console.error('An error occurred during the account creation process:', e)
-  } finally {
-    cy.task('wsDisconnect')
-  }
+  })
+  cy.task('wsDisconnect')
 })

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -340,6 +340,7 @@ Cypress.Commands.add(
                   const code = href.match(/code=([A-Za-z0-9]{8})/)
                   verification_code = code[1]
                   Cypress.env('walletsWithdrawalCode', verification_code)
+                  Cypress.env('emailVerificationCode', verification_code)
                   cy.log('Verification link found')
                 } else {
                   cy.log('Verification link not found')
@@ -392,6 +393,12 @@ Cypress.Commands.add('c_loadingCheck', () => {
 })
 
 Cypress.Commands.add('c_createRealAccount', () => {
+  //
+  cy.task('verifyEmailTask').then((accountEmail) => {
+    cy.log(accountEmail)
+    cy.c_emailVerification('account_opening_new.html', accountEmail)
+  })
+
   cy.task('createRealAccountTask').then((realAccountDetails) => {
     // Assuming realAccountDetails is an array where the first element is email
     const [email] = realAccountDetails

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -437,15 +437,20 @@ Cypress.Commands.add('c_loadingCheck', () => {
 
 Cypress.Commands.add('c_createRealAccount', () => {
   // Call Verify Email and then set the Verification code in env
-  cy.task('wsConnect')
-  cy.task('verifyEmailTask').then((accountEmail) => {
-    cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
-    cy.task('createRealAccountTask').then(() => {
-      // Updating Cypress environment variables with the new email
-      const currentCredentials = Cypress.env('credentials')
-      currentCredentials.test.masterUser.ID = accountEmail
-      Cypress.env('credentials', currentCredentials)
+  try {
+    cy.task('wsConnect')
+    cy.task('verifyEmailTask').then((accountEmail) => {
+      cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
+      cy.task('createRealAccountTask').then(() => {
+        // Updating Cypress environment variables with the new email
+        const currentCredentials = Cypress.env('credentials')
+        currentCredentials.test.masterUser.ID = accountEmail
+        Cypress.env('credentials', currentCredentials)
+      })
     })
-  })
-  cy.task('wsDisconnect')
+  } catch (e) {
+    console.error('An error occurred during the account creation process:', e)
+  } finally {
+    cy.task('wsDisconnect')
+  }
 })

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -340,7 +340,6 @@ Cypress.Commands.add(
                   const code = href.match(/code=([A-Za-z0-9]{8})/)
                   verification_code = code[1]
                   Cypress.env('walletsWithdrawalCode', verification_code)
-                  Cypress.env('emailVerificationCode', verification_code)
                   cy.log('Verification link found')
                 } else {
                   cy.log('Verification link not found')
@@ -403,7 +402,7 @@ Cypress.Commands.add(
               const code = href.match(/code=([A-Za-z0-9]{8})/)
               verification_code = code[1]
               cy.task('setVerificationCode', verification_code)
-              cy.log(verification_code)
+              cy.log('Verification link found')
             } else {
               cy.log('Verification link not found')
             }
@@ -442,7 +441,6 @@ Cypress.Commands.add('c_createRealAccount', () => {
     cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
   })
 
-  // create real account task
   cy.task('createRealAccountTask').then((realAccountDetails) => {
     // Assuming realAccountDetails is an array where the first element is email
     const [email] = realAccountDetails

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -393,18 +393,14 @@ Cypress.Commands.add('c_loadingCheck', () => {
 })
 
 Cypress.Commands.add('c_createRealAccount', () => {
-  //
+  // Call Verify Email and then set the Verification code in env
   cy.task('verifyEmailTask').then((accountEmail) => {
-    cy.log(accountEmail)
     cy.c_emailVerification('account_opening_new.html', accountEmail)
   })
 
   cy.task('createRealAccountTask').then((realAccountDetails) => {
     // Assuming realAccountDetails is an array where the first element is email
     const [email] = realAccountDetails
-    cy.wrap(realAccountDetails).as('realAccountDetails') // Wrap and alias for later use
-
-    cy.log(email) // Logging the email for debugging
 
     // Updating Cypress environment variables with the new email
     const currentCredentials = Cypress.env('credentials')

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -442,6 +442,7 @@ Cypress.Commands.add('c_createRealAccount', () => {
     cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
   })
 
+  // create real account task
   cy.task('createRealAccountTask').then((realAccountDetails) => {
     // Assuming realAccountDetails is an array where the first element is email
     const [email] = realAccountDetails

--- a/cypress/support/helper/accountCreationUtility.js
+++ b/cypress/support/helper/accountCreationUtility.js
@@ -1,24 +1,14 @@
 require('dotenv').config()
 
-const DerivAPI = require('@deriv/deriv-api/dist/DerivAPI')
-const WebSocket = require('ws')
 const {
   emailGenerator,
   numbersGenerator,
   nameGenerator,
 } = require('./commonJsUtility')
 
-const appId = process.env.E2E_STD_CONFIG_APPID
-const websocketURL = `wss://${process.env.E2E_STD_CONFIG_SERVER}/websockets/v3`
-
-const connection = new WebSocket(
-  `${websocketURL}?l=EN&app_id=${appId}&brand=deriv`
-)
-const api = new DerivAPI({ connection })
-
 const randomEmail = emailGenerator()
 
-const verifyEmail = async () => {
+const verifyEmail = async (api) => {
   await api.basic.verifyEmail({
     verify_email: randomEmail,
     type: 'account_opening',
@@ -27,6 +17,7 @@ const verifyEmail = async () => {
 }
 
 const createAccountVirtual = async (
+  api,
   password = process.env.E2E_DERIV_PASSWORD,
   residence = 'id'
 ) => {
@@ -48,9 +39,13 @@ const createAccountVirtual = async (
   }
 }
 
-const createAccountReal = async (clientResidence = 'id', currency = 'USD') => {
+const createAccountReal = async (
+  api,
+  clientResidence = 'id',
+  currency = 'USD'
+) => {
   try {
-    const resp = await createAccountVirtual()
+    const resp = await createAccountVirtual(api)
     const [, , oauth_token] = resp
     await api.account(oauth_token) // API authentication
 
@@ -80,11 +75,6 @@ const createAccountReal = async (clientResidence = 'id', currency = 'USD') => {
     return results
   } catch (e) {
     console.log(e)
-  } finally {
-    console.log(connection.readyState)
-    if (connection.readyState === WebSocket.OPEN) {
-      connection.close()
-    }
   }
 }
 

--- a/cypress/support/helper/accountCreationUtility.js
+++ b/cypress/support/helper/accountCreationUtility.js
@@ -1,5 +1,5 @@
 require('dotenv').config()
-const { chromium } = require('playwright')
+
 const DerivAPI = require('@deriv/deriv-api/dist/DerivAPI')
 const WebSocket = require('ws')
 const {
@@ -10,7 +10,6 @@ const {
 
 const appId = process.env.E2E_STD_CONFIG_APPID
 const websocketURL = `wss://${process.env.E2E_STD_CONFIG_SERVER}/websockets/v3`
-const basicAuthUrl = `https://${process.env.E2E_STD_CONFIG_SERVER}`
 
 const connection = new WebSocket(
   `${websocketURL}?l=EN&app_id=${appId}&brand=deriv`
@@ -26,72 +25,6 @@ const verifyEmail = async () => {
   })
   return randomEmail
 }
-
-// const getVerificationCode = async () => {
-//   // Launch browser
-//   const browser = await chromium.launch()
-//   try {
-//     await verifyEmail()
-
-//     const context = await browser.newContext({
-//       httpCredentials: {
-//         username: process.env.E2E_QABOX_LOGIN,
-//         password: process.env.E2E_QABOX_PASSWORD,
-//       },
-//     })
-//     const page = await context.newPage()
-
-//     // Navigate to /events to extract the email verification code
-//     await page.goto(`${basicAuthUrl}/events`)
-
-//     let verificationCode
-//     for (let retryCount = 0; retryCount < 3; retryCount++) {
-//       await page.evaluate(() => {
-//         const allRelatedEmails = Array.from(
-//           document.querySelectorAll(`a[href*="account_opening_new.html"]`)
-//         )
-//         if (allRelatedEmails.length) {
-//           const verificationEmail = allRelatedEmails.pop()
-//           verificationEmail.click()
-//         }
-//       })
-
-//       await page.waitForNavigation({ waitUntil: 'domcontentloaded' })
-
-//       // Extract the href attribute of the last link and process it
-//       const href = await page.evaluate(() => {
-//         const links = document.querySelectorAll('a')
-//         const targetLink = links[links.length - 1].getAttribute('href')
-//         return targetLink
-//       })
-
-//       const codeMatch = href.match(/code=([A-Za-z0-9]{8})/)
-//       if (codeMatch) {
-//         verificationCode = codeMatch[1]
-//       } else {
-//         console.log('Unable to find code in the URL')
-//       }
-
-//       if (verificationCode) {
-//         break
-//       }
-
-//       console.log(
-//         `Email not found. Retrying... Attempt number: ${retryCount + 1}`
-//       )
-//       await page.waitForTimeout(1000)
-//     }
-
-//     if (!verificationCode) {
-//       throw new Error(`Signup URL extraction failed after 3 attempts.`)
-//     }
-//     return verificationCode
-//   } catch (e) {
-//     console.log(e)
-//   } finally {
-//     await browser.close()
-//   }
-// }
 
 const createAccountVirtual = async (
   password = process.env.E2E_DERIV_PASSWORD,

--- a/cypress/support/helper/accountCreationUtility.js
+++ b/cypress/support/helper/accountCreationUtility.js
@@ -6,9 +6,8 @@ const {
   nameGenerator,
 } = require('./commonJsUtility')
 
-const randomEmail = emailGenerator()
-
 const verifyEmail = async (api) => {
+  const randomEmail = emailGenerator()
   await api.basic.verifyEmail({
     verify_email: randomEmail,
     type: 'account_opening',
@@ -33,7 +32,6 @@ const createAccountVirtual = async (
       new_account_virtual: { oauth_token },
     } = response
     return {
-      email: randomEmail,
       residence: residence,
       oauthToken: oauth_token,
     }
@@ -76,7 +74,6 @@ const createAccountReal = async (
       echo_req: { residence },
     } = response
     return {
-      email: randomEmail,
       clientID: client_id,
       residence: residence,
     }

--- a/cypress/support/helper/accountCreationUtility.js
+++ b/cypress/support/helper/accountCreationUtility.js
@@ -32,10 +32,14 @@ const createAccountVirtual = async (
     const {
       new_account_virtual: { oauth_token },
     } = response
-    const results = [randomEmail, residence, oauth_token]
-    return results
+    return {
+      email: randomEmail,
+      residence: residence,
+      oauthToken: oauth_token,
+    }
   } catch (e) {
-    console.log(e)
+    console.error('Operation failed', e)
+    throw e
   }
 }
 
@@ -46,8 +50,8 @@ const createAccountReal = async (
 ) => {
   try {
     const resp = await createAccountVirtual(api)
-    const [, , oauth_token] = resp
-    await api.account(oauth_token) // API authentication
+    const { oauthToken } = resp
+    await api.account(oauthToken) // API authentication
 
     const clientDetails = {
       new_account_real: 1,
@@ -71,10 +75,14 @@ const createAccountReal = async (
       new_account_real: { client_id },
       echo_req: { residence },
     } = response
-    const results = [randomEmail, client_id, residence]
-    return results
+    return {
+      email: randomEmail,
+      clientID: client_id,
+      residence: residence,
+    }
   } catch (e) {
-    console.log(e)
+    console.error('Operation failed', e)
+    throw e
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "mochawesome-merge": "^4.3.0",
         "mochawesome-report-generator": "^6.2.0",
         "pixelmatch": "^5.3.0",
-        "playwright": "^1.42.1",
         "pngjs": "^7.0.0",
         "prettier": "3.2.5",
         "ws": "^8.16.0"
@@ -3754,50 +3753,6 @@
       "dev": true,
       "engines": {
         "node": ">=12.13.0"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.42.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "mochawesome-merge": "^4.3.0",
     "mochawesome-report-generator": "^6.2.0",
     "pixelmatch": "^5.3.0",
-    "playwright": "^1.42.1",
     "pngjs": "^7.0.0",
     "prettier": "3.2.5",
     "ws": "^8.16.0"


### PR DESCRIPTION
### Improving api account creation functionality
In this PR, 
- I have done some improvements to the api account creation functions so that we can be able to re-run successfully the tests that use `c_createRealAccount` command in one cypress session. Before, it used to throw timeout error because no api calls were being made.
- I have refactored the function to use cypress command instead of playwright for **getting verification code** from the events url. If you check well, I'm using the new command `c_emailVerificationV2` but it's almost similar to `c_emailVerification` already existing.