### PR TITLE
New feature change for P2P test - Dropdown

### DIFF
--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -231,11 +231,10 @@ Cypress.Commands.add('c_postAd', () => {
 })
 
 Cypress.Commands.add('c_removeExistingAds', (adType) => {
-  cy.get('.my-ads-table__row')
-    .trigger('touchstart', 'right', { timeout: 1000 })
-    .trigger('touchmove', 'left')
-    .trigger('touchend')
-  cy.get('.my-ads-table__popovers-delete>svg').click({ force: true })
+  cy.get('.my-ads-table__row .dc-dropdown-container')
+    .should('be.visible')
+    .click()
+  cy.findByText('Delete').parent().click()
   cy.findByText('Do you want to delete this ad?').should('be.visible')
   cy.findByText('You will NOT be able to restore it.').should('be.visible')
   cy.findByRole('button', { name: 'Delete' })


### PR DESCRIPTION
The change due to card -> [[FE] - Copy Advert](https://app.clickup.com/t/20696747/P2PS-2244)


Now we have a dropdown instead of swiping ad to the left. 
Failure: [Cypress Cloud](https://cloud.cypress.io/projects/9szghx/runs/38/test-results?utm_source=slack&utm_medium=failed&utm_campaign=view%20spec&specs=%5B%7B%22value%22%3A%22%5B%5C%22ad289789-918d-4bd0-8af5-6c1c54b89ee4%5C%22%5D%22%2C%22label%22%3A%22cypress%2Fe2e%2Fwip%2FP2P%2FcreateAdSellFixedRate.cy.js%22%7D%5D&statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D)

![image (4)](https://github.com/deriv-com/e2e-deriv-app/assets/152943428/03ac8958-02fe-4428-8843-f34071e381c8)
