### PR TITLE
P2P - Responsive - Fixed Rate - Delete Ad

### DIFF
--- a/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
+++ b/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
@@ -3,7 +3,6 @@ import '@testing-library/cypress/add-commands'
 let fixedRate = 1.25
 let minOrder = 5
 let maxOrder = 10
-let boolAdExistence
 
 function verifyAdOnMyAdsScreen(fiatCurrency, localCurrency) {
   cy.findByText('Active').should('be.visible')

--- a/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
+++ b/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
@@ -13,7 +13,7 @@ function verifyAdOnMyAdsScreen(fiatCurrency, localCurrency) {
   )
 }
 
-describe('QATEST-2403 - Create a Buy type Advert - Fixed Rate', () => {
+describe('QATEST-2482 - Delete Advert - Fixed Rate', () => {
   beforeEach(() => {
     cy.clearAllLocalStorage()
     cy.clearAllSessionStorage()
@@ -21,7 +21,7 @@ describe('QATEST-2403 - Create a Buy type Advert - Fixed Rate', () => {
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
 
-  it('Should be able to create buy type advert and verify all fields and messages for fixed rate.', () => {
+  it('Should be able to delete newly created advert for fixed rate.', () => {
     cy.c_navigateToDerivP2P()
     cy.c_closeSafetyInstructions()
     cy.findByText('Deriv P2P').should('exist')

--- a/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
+++ b/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
@@ -1,0 +1,68 @@
+import '@testing-library/cypress/add-commands'
+
+let fixedRate = 1.25
+let minOrder = 5
+let maxOrder = 10
+
+function verifyAdOnMyAdsScreen(fiatCurrency, localCurrency) {
+  cy.findByText('Active').should('be.visible')
+  cy.findByText(`Buy ${fiatCurrency}`).should('be.visible')
+  cy.findByText(`${fixedRate} ${localCurrency}`)
+  cy.findByText(
+    `${minOrder.toFixed(2)} - ${maxOrder.toFixed(2)} ${fiatCurrency}`
+  )
+}
+
+describe('QATEST-2403 - Create a Buy type Advert - Fixed Rate', () => {
+  beforeEach(() => {
+    cy.clearAllLocalStorage()
+    cy.clearAllSessionStorage()
+    cy.c_login({ user: 'p2pFixedRate' })
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
+  })
+
+  it('Should be able to create buy type advert and verify all fields and messages for fixed rate.', () => {
+    cy.c_navigateToDerivP2P()
+    cy.c_closeSafetyInstructions()
+    cy.findByText('Deriv P2P').should('exist')
+    cy.c_closeNotificationHeader()
+    cy.c_clickMyAdTab()
+    cy.c_createNewAd('buy')
+    cy.findByText('Buy USD').click()
+    cy.findByText("You're creating an ad to buy...").should('be.visible')
+    cy.findByTestId('offer_amount')
+      .next('span.dc-text')
+      .invoke('text')
+      .then((fiatCurrency) => {
+        sessionStorage.setItem('c_fiatCurrency', fiatCurrency.trim())
+      })
+    cy.findByTestId('fixed_rate_type')
+      .next('span.dc-text')
+      .invoke('text')
+      .then((localCurrency) => {
+        sessionStorage.setItem('c_localCurrency', localCurrency.trim())
+      })
+    cy.then(() => {
+      cy.c_verifyAmountFiled()
+      cy.c_verifyFixedRate(
+        'buy',
+        10,
+        fixedRate,
+        sessionStorage.getItem('c_fiatCurrency'),
+        sessionStorage.getItem('c_localCurrency')
+      )
+      cy.c_verifyMaxMin('min_transaction', minOrder, 'Min')
+      cy.c_verifyMaxMin('max_transaction', maxOrder, 'Max')
+      cy.c_verifyTextAreaBlock('default_advert_description')
+      cy.c_verifyTooltip()
+      cy.c_verifyCompletionOrderDropdown()
+      cy.c_PaymentMethod()
+      cy.c_verifyPostAd()
+      verifyAdOnMyAdsScreen(
+        sessionStorage.getItem('c_fiatCurrency'),
+        sessionStorage.getItem('c_localCurrency')
+      )
+      cy.c_removeExistingAds()
+    })
+  })
+})

--- a/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
+++ b/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
@@ -29,7 +29,6 @@ describe('QATEST-2482 - Delete Advert - Fixed Rate', () => {
     cy.c_closeNotificationHeader()
     cy.c_clickMyAdTab()
     cy.c_checkForExistingAds().then((returnedValue) => {
-      cy.log('hello ' + returnedValue)
       if (returnedValue === 0) {
         cy.c_createNewAd('buy')
         cy.findByText('Buy USD').click()

--- a/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
+++ b/cypress/e2e/wip/P2P/deleteAdFixedRate.cy.js
@@ -27,8 +27,8 @@ describe('QATEST-2482 - Delete Advert - Fixed Rate', () => {
     cy.findByText('Deriv P2P').should('exist')
     cy.c_closeNotificationHeader()
     cy.c_clickMyAdTab()
-    cy.c_checkForExistingAds().then((returnedValue) => {
-      if (returnedValue === 0) {
+    cy.c_checkForExistingAds().then((adExists) => {
+      if (adExists == false) {
         cy.c_createNewAd('buy')
         cy.findByText('Buy USD').click()
         cy.findByText("You're creating an ad to buy...").should('be.visible')
@@ -66,11 +66,9 @@ describe('QATEST-2482 - Delete Advert - Fixed Rate', () => {
             sessionStorage.getItem('c_fiatCurrency'),
             sessionStorage.getItem('c_localCurrency')
           )
-          cy.c_removeExistingAds()
         })
-      } else if (returnedValue === 1) {
-        cy.c_removeExistingAds()
       }
+      cy.c_removeExistingAds()
     })
   })
 })

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -111,6 +111,17 @@ Cypress.Commands.add('c_verifyTextAreaLength', (blockName, textLength) => {
     .should('contain.text', `${textLength}/300`)
 })
 
+Cypress.Commands.add('c_checkForExistingAds', () => {
+  cy.findByTestId('dt_initial_loader').should('not.exist')
+  return cy.get('body', { timeout: 10000 }).then((body) => {
+    if (body.find('.no-ads__message', { timeout: 10000 }).length > 0) {
+      return 0 // No ads found
+    } else if (body.find('#toggle-my-ads', { timeout: 10000 }).length > 0) {
+      return 1 // Ads found
+    }
+  })
+})
+
 Cypress.Commands.add('c_verifyRate', () => {
   cy.findByTestId('float_rate_type').click().clear()
   cy.findByText('Floating rate is required').should('be.visible')

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -112,12 +112,12 @@ Cypress.Commands.add('c_verifyTextAreaLength', (blockName, textLength) => {
 })
 
 Cypress.Commands.add('c_checkForExistingAds', () => {
-  cy.findByTestId('dt_initial_loader').should('not.exist')
+  cy.c_loadingCheck()
   return cy.get('body', { timeout: 10000 }).then((body) => {
     if (body.find('.no-ads__message', { timeout: 10000 }).length > 0) {
-      return 0 // No ads found
+      return false // No ads found
     } else if (body.find('#toggle-my-ads', { timeout: 10000 }).length > 0) {
-      return 1 // Ads found
+      return true // Ads found
     }
   })
 })

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -115,9 +115,9 @@ Cypress.Commands.add('c_checkForExistingAds', () => {
   cy.c_loadingCheck()
   return cy.get('body', { timeout: 10000 }).then((body) => {
     if (body.find('.no-ads__message', { timeout: 10000 }).length > 0) {
-      return false // No ads found
+      return false
     } else if (body.find('#toggle-my-ads', { timeout: 10000 }).length > 0) {
-      return true // Ads found
+      return true
     }
   })
 })


### PR DESCRIPTION
Test will do the following:

1. If ad exists, it will delete it and the test ends. 

2. If no ad exists, it will create a new ad and then delete it and the test ends. 

This has been catered to not always create ad and do deletion. And to decrease time of test run. 

**Note**: Both of the above scenarios have been tested. 

[ClickUp Card](https://app.clickup.com/t/20696747/P2PS-2427)

![image](https://github.com/deriv-com/e2e-deriv-app/assets/152943428/f2ef6c15-c385-490b-a55a-86c3fccbb958)
