### PR TITLE
createRealAccount command to accept country and currency

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -52,18 +52,18 @@ module.exports = defineConfig({
         
           return null;
         },
-        async createRealAccountTask() {
+        async createRealAccountTask({country_code, currency}) {
           try {
-            const realAccountDetails = await createAccountReal(api);
+            const realAccountDetails = await createAccountReal(api, country_code, currency);
             return realAccountDetails;
           } catch (error) {
             console.error('Error creating account:', error);
             throw error;
           }
         },
-        async createVirtualAccountTask() {
+        async createVirtualAccountTask({country_code}) {
           try {
-              const virtualAccountDetails = await createAccountVirtual(api);
+              const virtualAccountDetails = await createAccountVirtual(api, country_code);
               return virtualAccountDetails;
           } catch (error) {
               console.error('Error creating virtual account:', error);

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -452,25 +452,35 @@ Cypress.Commands.add('c_loadingCheck', () => {
   cy.findByTestId('dt_initial_loader').should('not.exist')
 })
 
-Cypress.Commands.add('c_createRealAccount', () => {
-  // Call Verify Email and then set the Verification code in env
-  try {
-    cy.task('wsConnect')
-    cy.task('verifyEmailTask').then((accountEmail) => {
-      cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
-      cy.task('createRealAccountTask').then(() => {
-        // Updating Cypress environment variables with the new email
-        const currentCredentials = Cypress.env('credentials')
-        currentCredentials.test.masterUser.ID = accountEmail
-        Cypress.env('credentials', currentCredentials)
+/*
+  Usage cy.c_createRealAccount('co', 'EUR') or you may not pass in anything to go with default.
+  Currently works for CR countries as well as DIEL - non-EU account.
+*/
+Cypress.Commands.add(
+  'c_createRealAccount',
+  (country_code = 'id', currency = 'USD') => {
+    // Call Verify Email and then set the Verification code in env
+    try {
+      cy.task('wsConnect')
+      cy.task('verifyEmailTask').then((accountEmail) => {
+        cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
+        cy.task('createVirtualAccountTask', {
+          country_code: country_code,
+          currency: currency,
+        }).then(() => {
+          // Updating Cypress environment variables with the new email
+          const currentCredentials = Cypress.env('credentials')
+          currentCredentials.test.masterUser.ID = accountEmail
+          Cypress.env('credentials', currentCredentials)
+        })
       })
-    })
-  } catch (e) {
-    console.error('An error occurred during the account creation process:', e)
-  } finally {
-    cy.task('wsDisconnect')
+    } catch (e) {
+      console.error('An error occurred during the account creation process:', e)
+    } finally {
+      cy.task('wsDisconnect')
+    }
   }
-})
+)
 
 Cypress.Commands.add('c_closeModal', () => {
   cy.log('Closing the modal')

--- a/cypress/support/helper/accountCreationUtility.js
+++ b/cypress/support/helper/accountCreationUtility.js
@@ -17,22 +17,22 @@ const verifyEmail = async (api) => {
 
 const createAccountVirtual = async (
   api,
-  password = process.env.E2E_DERIV_PASSWORD,
-  residence = 'id'
+  country_code,
+  password = process.env.E2E_DERIV_PASSWORD
 ) => {
   try {
     const response = await api.basic.newAccountVirtual({
       new_account_virtual: 1,
       type: 'trading',
       client_password: password,
-      residence: residence,
+      residence: country_code,
       verification_code: process.env.E2E_EMAIL_VERIFICATION_CODE,
     })
     const {
       new_account_virtual: { oauth_token },
     } = response
     return {
-      residence: residence,
+      residence: country_code,
       oauthToken: oauth_token,
     }
   } catch (e) {
@@ -41,13 +41,9 @@ const createAccountVirtual = async (
   }
 }
 
-const createAccountReal = async (
-  api,
-  clientResidence = 'id',
-  currency = 'USD'
-) => {
+const createAccountReal = async (api, country_code, currency) => {
   try {
-    const resp = await createAccountVirtual(api)
+    const resp = await createAccountVirtual(api, country_code)
     const { oauthToken } = resp
     await api.account(oauthToken) // API authentication
 
@@ -59,8 +55,8 @@ const createAccountReal = async (
       first_name: 'Auto Gen',
       last_name: nameGenerator(),
       date_of_birth: '2000-09-20',
-      place_of_birth: clientResidence,
-      residence: clientResidence,
+      place_of_birth: country_code,
+      residence: country_code,
       phone: `+${numbersGenerator()}`,
       address_line_1: '20 Broadway Av',
       address_city: 'Cyber',


### PR DESCRIPTION
### createRealAccount command to accept country_code and currency as arguments
In this PR, I have improved the api account creation function to accept country_code(eg: 'co') and currency(eg: 'USD') as arguments.
This will allow someone to create account from the country of residence they want as well as the currency they want.
USAGE:
`cy.c_createRealAccount('co', 'EUR')` // This one creates a colombian real account with EURO fiat currency
NOTE: 
You can still use `cy.c_createRealAccount()` // This one creates an Indonesian real account with USD fiat currency
If you want to go with the default.