### PR TITLE
P2P - Responsive - Fixed Rate - Copy Buy Ad

### DIFF
--- a/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
+++ b/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
@@ -1,0 +1,109 @@
+import '@testing-library/cypress/add-commands'
+
+let fixedRate = 1.25
+let minOrder = 5
+let maxOrder = 10
+
+function verifyAdOnMyAdsScreen(fiatCurrency, localCurrency) {
+  cy.findByText('Active').should('be.visible')
+  cy.findByText(`Buy ${fiatCurrency}`).should('be.visible')
+  cy.findByText(`${fixedRate} ${localCurrency}`)
+  cy.findByText(
+    `${minOrder.toFixed(2)} - ${maxOrder.toFixed(2)} ${fiatCurrency}`
+  )
+}
+
+describe('QATEST-145618 - Copy Ad - Fixed Rate - Buy Ad', () => {
+  beforeEach(() => {
+    cy.clearAllLocalStorage()
+    cy.clearAllSessionStorage()
+    cy.c_login({ user: 'p2pFixedRate' })
+    cy.c_visitResponsive('/appstore/traders-hub', 'small')
+  })
+
+  it('Should be able to copy an already existing buy type advert successfully.', () => {
+    cy.c_navigateToDerivP2P()
+    cy.c_closeSafetyInstructions()
+    cy.findByText('Deriv P2P').should('exist')
+    cy.c_closeNotificationHeader()
+    cy.c_clickMyAdTab()
+    cy.c_checkForExistingAds().then((adExists) => {
+      if (adExists == false) {
+        cy.c_createNewAd('buy')
+        cy.findByText('Buy USD').click()
+        cy.findByText("You're creating an ad to buy...").should('be.visible')
+        cy.findByTestId('offer_amount')
+          .next('span.dc-text')
+          .invoke('text')
+          .then((fiatCurrency) => {
+            sessionStorage.setItem('c_fiatCurrency', fiatCurrency.trim())
+          })
+        cy.findByTestId('fixed_rate_type')
+          .next('span.dc-text')
+          .invoke('text')
+          .then((localCurrency) => {
+            sessionStorage.setItem('c_localCurrency', localCurrency.trim())
+          })
+        cy.then(() => {
+          cy.findByTestId('offer_amount').type('10').should('have.value', '10')
+          cy.findByTestId('fixed_rate_type')
+            .type(fixedRate)
+            .should('have.value', fixedRate)
+          cy.findByTestId('min_transaction')
+            .type(minOrder)
+            .should('have.value', minOrder)
+          cy.findByTestId('max_transaction')
+            .type(maxOrder)
+            .should('have.value', maxOrder)
+          cy.findByTestId('default_advert_description')
+            .type('Description Block')
+            .should('have.value', 'Description Block')
+          cy.findByTestId('dt_dropdown_display').click()
+          cy.get('#900').should('be.visible').click()
+          cy.c_PaymentMethod()
+          cy.c_verifyPostAd()
+          verifyAdOnMyAdsScreen(
+            sessionStorage.getItem('c_fiatCurrency'),
+            sessionStorage.getItem('c_localCurrency')
+          )
+        })
+      }
+    })
+    cy.c_createNewAd('buy')
+    cy.findByText('Buy USD').click()
+    cy.findByText("You're creating an ad to buy...").should('be.visible')
+    cy.findByTestId('offer_amount')
+      .next('span.dc-text')
+      .invoke('text')
+      .then((fiatCurrency) => {
+        sessionStorage.setItem('c_fiatCurrency', fiatCurrency.trim())
+      })
+    cy.findByTestId('fixed_rate_type')
+      .next('span.dc-text')
+      .invoke('text')
+      .then((localCurrency) => {
+        sessionStorage.setItem('c_localCurrency', localCurrency.trim())
+      })
+    cy.then(() => {
+      cy.c_verifyAmountFiled()
+      cy.c_verifyFixedRate(
+        'buy',
+        10,
+        fixedRate,
+        sessionStorage.getItem('c_fiatCurrency'),
+        sessionStorage.getItem('c_localCurrency')
+      )
+      cy.c_verifyMaxMin('min_transaction', minOrder, 'Min')
+      cy.c_verifyMaxMin('max_transaction', maxOrder, 'Max')
+      cy.c_verifyTextAreaBlock('default_advert_description')
+      cy.c_verifyTooltip()
+      cy.c_verifyCompletionOrderDropdown()
+      cy.c_PaymentMethod()
+      cy.c_verifyPostAd()
+      verifyAdOnMyAdsScreen(
+        sessionStorage.getItem('c_fiatCurrency'),
+        sessionStorage.getItem('c_localCurrency')
+      )
+    })
+  })
+})

--- a/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
+++ b/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
@@ -1,7 +1,7 @@
 import '@testing-library/cypress/add-commands'
 
 let fixedRate = 1.25
-let minOrder = 5
+let minOrder = 6
 let maxOrder = 10
 
 function verifyAdOnMyAdsScreen(fiatCurrency, localCurrency) {
@@ -30,71 +30,9 @@ describe('QATEST-145618 - Copy Ad - Fixed Rate - Buy Ad', () => {
     cy.c_checkForExistingAds().then((adExists) => {
       if (adExists == false) {
         cy.c_createNewAd('buy')
-        cy.findByText('Buy USD').click()
-        cy.findByText("You're creating an ad to buy...").should('be.visible')
-        cy.findByTestId('offer_amount')
-          .next('span.dc-text')
-          .invoke('text')
-          .then((fiatCurrency) => {
-            sessionStorage.setItem('c_fiatCurrency', fiatCurrency.trim())
-          })
-        cy.findByTestId('fixed_rate_type')
-          .next('span.dc-text')
-          .invoke('text')
-          .then((localCurrency) => {
-            sessionStorage.setItem('c_localCurrency', localCurrency.trim())
-          })
-        cy.then(() => {
-          cy.findByTestId('offer_amount').type('10').should('have.value', '10')
-          cy.findByTestId('fixed_rate_type')
-            .type(fixedRate)
-            .should('have.value', fixedRate)
-          cy.findByTestId('min_transaction')
-            .type(minOrder)
-            .should('have.value', minOrder)
-          cy.findByTestId('max_transaction')
-            .type(maxOrder)
-            .should('have.value', maxOrder)
-          cy.findByTestId('default_advert_description')
-            .type('Description Block')
-            .should('have.value', 'Description Block')
-          cy.findByTestId('dt_dropdown_display').click()
-          cy.get('#900').should('be.visible').click()
-          cy.c_PaymentMethod()
-          cy.c_verifyPostAd()
-          verifyAdOnMyAdsScreen(
-            sessionStorage.getItem('c_fiatCurrency'),
-            sessionStorage.getItem('c_localCurrency')
-          )
-        })
+        cy.c_inputAdDetails(fixedRate, minOrder, maxOrder, 'Buy', 'fixed')
       }
-      cy.get('.my-ads-table__row .dc-dropdown-container')
-        .should('be.visible')
-        .click()
-      cy.findByText('Edit').parent().click()
-      cy.findByTestId('offer_amount')
-        .invoke('val')
-        .then((offerAmount) => {
-          sessionStorage.setItem('c_offerAmount', offerAmount)
-        })
-      cy.findByTestId('fixed_rate_type')
-        .invoke('val')
-        .then((rateValue) => {
-          sessionStorage.setItem('c_rateValue', rateValue.trim())
-        })
-      cy.findByTestId('description')
-        .invoke('text')
-        .then((instructions) => {
-          sessionStorage.setItem('c_instructions', instructions.trim())
-        })
-      cy.get('span[name="order_completion_time"]')
-        .invoke('text')
-        .then((orderCompletionTime) => {
-          sessionStorage.setItem(
-            'c_orderCompletionTime',
-            orderCompletionTime.trim()
-          )
-        })
+      cy.c_getExistingAdDetailsForValidation('Buy')
       cy.then(() => {
         cy.findByTestId('dt_page_return_icon').click()
         cy.contains('span[class="dc-text"]', 'Buy USD')
@@ -106,8 +44,10 @@ describe('QATEST-145618 - Copy Ad - Fixed Rate - Buy Ad', () => {
           sessionStorage.getItem('c_offerAmount'),
           sessionStorage.getItem('c_rateValue'),
           sessionStorage.getItem('c_instructions'),
-          sessionStorage.getItem('c_orderCompletionTime')
+          sessionStorage.getItem('c_orderCompletionTime'),
+          null
         )
+        cy.c_deleteCopiedAd()
       })
     })
   })

--- a/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
+++ b/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
@@ -68,22 +68,47 @@ describe('QATEST-145618 - Copy Ad - Fixed Rate - Buy Ad', () => {
           )
         })
       }
-      cy.contains('span[class="dc-text"]', 'Buy USD')
-        .siblings('.dc-dropdown-container')
+      cy.get('.my-ads-table__row .dc-dropdown-container')
         .should('be.visible')
         .click()
-      cy.findByText('Copy').parent().click()
-      cy.get('.dc-text')
-        .contains('Ad type')
-        .next('.copy-advert-form__field')
+      cy.findByText('Edit').parent().click()
+      cy.findByTestId('offer_amount')
+        .invoke('val')
+        .then((offerAmount) => {
+          sessionStorage.setItem('c_offerAmount', offerAmount)
+        })
+      cy.findByTestId('fixed_rate_type')
+        .invoke('val')
+        .then((rateValue) => {
+          sessionStorage.setItem('c_rateValue', rateValue.trim())
+        })
+      cy.findByTestId('description')
         .invoke('text')
-        .then((adType) => {
-          sessionStorage.setItem('c_adType', adType.trim())
+        .then((instructions) => {
+          sessionStorage.setItem('c_instructions', instructions.trim())
+        })
+      cy.get('span[name="order_completion_time"]')
+        .invoke('text')
+        .then((orderCompletionTime) => {
+          sessionStorage.setItem(
+            'c_orderCompletionTime',
+            orderCompletionTime.trim()
+          )
         })
       cy.then(() => {
-        cy.log(sessionStorage.getItem('c_adType'))
+        cy.findByTestId('dt_page_return_icon').click()
+        cy.contains('span[class="dc-text"]', 'Buy USD')
+          .siblings('.dc-dropdown-container')
+          .should('be.visible')
+          .click()
+        cy.findByText('Copy').parent().click()
+        cy.c_copyExistingAd(
+          sessionStorage.getItem('c_offerAmount'),
+          sessionStorage.getItem('c_rateValue'),
+          sessionStorage.getItem('c_instructions'),
+          sessionStorage.getItem('c_orderCompletionTime')
+        )
       })
-      //cy.c_copyExistingAd(sessionStorage.getItem('c_adType'))
     })
   })
 })

--- a/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
+++ b/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
@@ -68,42 +68,7 @@ describe('QATEST-145618 - Copy Ad - Fixed Rate - Buy Ad', () => {
           )
         })
       }
-    })
-    cy.c_createNewAd('buy')
-    cy.findByText('Buy USD').click()
-    cy.findByText("You're creating an ad to buy...").should('be.visible')
-    cy.findByTestId('offer_amount')
-      .next('span.dc-text')
-      .invoke('text')
-      .then((fiatCurrency) => {
-        sessionStorage.setItem('c_fiatCurrency', fiatCurrency.trim())
-      })
-    cy.findByTestId('fixed_rate_type')
-      .next('span.dc-text')
-      .invoke('text')
-      .then((localCurrency) => {
-        sessionStorage.setItem('c_localCurrency', localCurrency.trim())
-      })
-    cy.then(() => {
-      cy.c_verifyAmountFiled()
-      cy.c_verifyFixedRate(
-        'buy',
-        10,
-        fixedRate,
-        sessionStorage.getItem('c_fiatCurrency'),
-        sessionStorage.getItem('c_localCurrency')
-      )
-      cy.c_verifyMaxMin('min_transaction', minOrder, 'Min')
-      cy.c_verifyMaxMin('max_transaction', maxOrder, 'Max')
-      cy.c_verifyTextAreaBlock('default_advert_description')
-      cy.c_verifyTooltip()
-      cy.c_verifyCompletionOrderDropdown()
-      cy.c_PaymentMethod()
-      cy.c_verifyPostAd()
-      verifyAdOnMyAdsScreen(
-        sessionStorage.getItem('c_fiatCurrency'),
-        sessionStorage.getItem('c_localCurrency')
-      )
+      cy.c_copyExistingAds()
     })
   })
 })

--- a/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
+++ b/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
@@ -68,7 +68,7 @@ describe('QATEST-145618 - Copy Ad - Fixed Rate - Buy Ad', () => {
           )
         })
       }
-      cy.c_copyExistingAds()
+      cy.c_copyExistingAd()
     })
   })
 })

--- a/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
+++ b/cypress/e2e/wip/P2P/copyAdFixedRateBuy.cy.js
@@ -68,7 +68,22 @@ describe('QATEST-145618 - Copy Ad - Fixed Rate - Buy Ad', () => {
           )
         })
       }
-      cy.c_copyExistingAd()
+      cy.contains('span[class="dc-text"]', 'Buy USD')
+        .siblings('.dc-dropdown-container')
+        .should('be.visible')
+        .click()
+      cy.findByText('Copy').parent().click()
+      cy.get('.dc-text')
+        .contains('Ad type')
+        .next('.copy-advert-form__field')
+        .invoke('text')
+        .then((adType) => {
+          sessionStorage.setItem('c_adType', adType.trim())
+        })
+      cy.then(() => {
+        cy.log(sessionStorage.getItem('c_adType'))
+      })
+      //cy.c_copyExistingAd(sessionStorage.getItem('c_adType'))
     })
   })
 })

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -122,6 +122,82 @@ Cypress.Commands.add('c_checkForExistingAds', () => {
   })
 })
 
+Cypress.Commands.add('c_getAdTypeAndRateType', () => {
+  cy.get('.dc-text')
+    .contains('Ad type')
+    .next('.copy-advert-form__field')
+    .invoke('text')
+    .then((adType) => {
+      sessionStorage.setItem('c_adType', adType.trim())
+    })
+  cy.get('.dc-input__container')
+    .children('.dc-input__label')
+    .eq(1)
+    .invoke('text')
+    .then((rateType) => {
+      sessionStorage.setItem('c_rateType', rateType.trim())
+    })
+  cy.then(() => {
+    return cy.wrap({
+      adType: sessionStorage.getItem('c_adType'),
+      rateType: sessionStorage.getItem('c_rateType'),
+    })
+  })
+})
+
+Cypress.Commands.add(
+  'c_copyExistingAd',
+  (offerAmount, rateValue, instructions, orderCompletionTime) => {
+    cy.c_getAdTypeAndRateType().then(({ adType, rateType }) => {
+      if (adType == 'Buy' && rateType == 'Fixed Rate') {
+        cy.findByTestId('offer_amount')
+          .invoke('val')
+          .then((offerAmountFromCopyAdScreen) => {
+            cy.log(
+              'Offer amounts match:',
+              offerAmount === offerAmountFromCopyAdScreen
+            )
+          })
+        cy.findByTestId('fixed_rate_type')
+          .invoke('val')
+          .then((rateValueFromCopyAdScreen) => {
+            cy.log(
+              'Offer amounts match:',
+              rateValue === rateValueFromCopyAdScreen
+            )
+          })
+        cy.get('span[class="dc-text"]')
+          .contains('Instructions')
+          .next()
+          .invoke('text')
+          .then((instructionsFromCopyAdScreen) => {
+            cy.log(
+              'Offer amounts match:',
+              instructions === instructionsFromCopyAdScreen
+            )
+          })
+        cy.get('span[class="dc-text"]')
+          .contains('Order must be completed in')
+          .next()
+          .invoke('text')
+          .then((orderCompletionTimeFromCopyAds) => {
+            cy.log(
+              'Offer amounts match:',
+              orderCompletionTime === orderCompletionTimeFromCopyAds
+            )
+          })
+        cy.findByTestId('offer_amount')
+          .clear()
+          .type(parseFloat(offerAmount) + 1)
+          .should('have.value', parseFloat(offerAmount) + 1)
+      } else if (adType == 'Sell' && rateType == 'Fixed Rate') {
+      } else if (adType == 'Buy' && rateType == 'Floating Rate') {
+      } else if (adType == 'Sell' && rateType == 'Floating Rate') {
+      }
+    })
+  }
+)
+
 Cypress.Commands.add('c_verifyRate', () => {
   cy.findByTestId('float_rate_type').click().clear()
   cy.findByText('Floating rate is required').should('be.visible')

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -5,6 +5,7 @@ let marketRate
 let rateCalculation
 let calculatedValue
 let regexPattern
+let paymentIDForCopyAdSell = generateAccountNumberString(12)
 
 Cypress.Commands.add('c_createNewAd', (adType) => {
   cy.findByTestId('dt_initial_loader').should('not.exist')
@@ -146,18 +147,156 @@ Cypress.Commands.add('c_getAdTypeAndRateType', () => {
 })
 
 Cypress.Commands.add(
+  'c_inputAdDetails',
+  (rateValue, minOrder, maxOrder, adType, rateType) => {
+    cy.findByText(`${adType} USD`).click()
+    cy.findByText(`You're creating an ad to ${adType.toLowerCase()}...`).should(
+      'be.visible'
+    )
+    cy.findByTestId('offer_amount')
+      .next('span.dc-text')
+      .invoke('text')
+      .then((fiatCurrency) => {
+        sessionStorage.setItem('c_fiatCurrency', fiatCurrency.trim())
+      })
+    if (rateType == 'fixed') {
+      cy.findByTestId('fixed_rate_type')
+        .next('span.dc-text')
+        .invoke('text')
+        .then((localCurrency) => {
+          sessionStorage.setItem('c_localCurrency', localCurrency.trim())
+        })
+    } else if (rateType == 'float') {
+      cy.findByTestId('float_rate_type')
+        .next('span.dc-text')
+        .invoke('text')
+        .then((localCurrency) => {
+          sessionStorage.setItem('c_localCurrency', localCurrency.trim())
+        })
+    }
+    cy.then(() => {
+      cy.findByTestId('offer_amount').type('10').should('have.value', '10')
+      if (rateType == 'fixed') {
+        cy.findByTestId('fixed_rate_type')
+          .type(rateValue)
+          .should('have.value', rateValue)
+      } else if (rateType == 'float') {
+        cy.findByTestId('float_rate_type')
+          .type(rateValue)
+          .should('have.value', rateValue)
+      }
+      cy.findByTestId('min_transaction')
+        .type(minOrder)
+        .should('have.value', minOrder)
+      cy.findByTestId('max_transaction')
+        .type(maxOrder)
+        .should('have.value', maxOrder)
+      if (adType == 'Sell') {
+        cy.findByTestId('contact_info')
+          .type('Contact Info Block')
+          .should('have.value', 'Contact Info Block')
+      }
+      cy.findByTestId('default_advert_description')
+        .type('Description Block')
+        .should('have.value', 'Description Block')
+      cy.findByTestId('dt_dropdown_display').click()
+      cy.get('#900').should('be.visible').click()
+      if (adType == 'Sell') {
+        cy.findByTestId('dt_payment_method_card_add_icon')
+          .should('be.visible')
+          .click()
+        cy.c_addPaymentMethod(paymentIDForCopyAdSell, 'PayPal')
+        cy.findByText(paymentIDForCopyAdSell)
+          .should('exist')
+          .parent()
+          .prev()
+          .find('.dc-checkbox')
+          .and('exist')
+          .click()
+      } else if (adType == 'Buy') {
+        cy.c_PaymentMethod()
+      }
+      cy.c_verifyPostAd()
+      cy.c_verifyAdOnMyAdsScreen(
+        adType,
+        sessionStorage.getItem('c_fiatCurrency'),
+        sessionStorage.getItem('c_localCurrency'),
+        rateValue,
+        minOrder,
+        maxOrder
+      )
+    })
+  }
+)
+
+Cypress.Commands.add(
+  'c_verifyAdOnMyAdsScreen',
+  (adType, fiatCurrency, localCurrency, rateValue, minOrder, maxOrder) => {
+    cy.findByText('Active').should('be.visible')
+    cy.findByText(`${adType} ${fiatCurrency}`).should('be.visible')
+    cy.findByText(`${rateValue} ${localCurrency}`)
+    cy.findByText(
+      `${minOrder.toFixed(2)} - ${maxOrder.toFixed(2)} ${fiatCurrency}`
+    )
+  }
+)
+
+Cypress.Commands.add('c_getExistingAdDetailsForValidation', (adType) => {
+  cy.get('.my-ads-table__row .dc-dropdown-container')
+    .should('be.visible')
+    .click()
+  cy.findByText('Edit').parent().click()
+  cy.findByTestId('offer_amount')
+    .invoke('val')
+    .then((offerAmount) => {
+      sessionStorage.setItem('c_offerAmount', offerAmount)
+    })
+  cy.findByTestId('fixed_rate_type')
+    .invoke('val')
+    .then((rateValue) => {
+      sessionStorage.setItem('c_rateValue', rateValue.trim())
+    })
+  if (adType == 'Sell') {
+    cy.findByTestId('contact_info')
+      .invoke('text')
+      .then((contactInfo) => {
+        sessionStorage.setItem('c_contactInfo', contactInfo.trim())
+      })
+  }
+  cy.findByTestId('description')
+    .invoke('text')
+    .then((instructions) => {
+      sessionStorage.setItem('c_instructions', instructions.trim())
+    })
+  cy.get('span[name="order_completion_time"]')
+    .invoke('text')
+    .then((orderCompletionTime) => {
+      sessionStorage.setItem(
+        'c_orderCompletionTime',
+        orderCompletionTime.trim()
+      )
+    })
+})
+
+Cypress.Commands.add(
   'c_copyExistingAd',
-  (offerAmount, rateValue, instructions, orderCompletionTime) => {
+  (
+    offerAmount,
+    rateValue,
+    instructions,
+    orderCompletionTime,
+    contactDetails
+  ) => {
     cy.c_getAdTypeAndRateType().then(({ adType, rateType }) => {
-      if (adType == 'Buy' && rateType == 'Fixed Rate') {
-        cy.findByTestId('offer_amount')
-          .invoke('val')
-          .then((offerAmountFromCopyAdScreen) => {
-            cy.log(
-              'Offer amounts match:',
-              offerAmount === offerAmountFromCopyAdScreen
-            )
-          })
+      cy.findByTestId('offer_amount')
+        .invoke('val')
+        .then((offerAmountFromCopyAdScreen) => {
+          cy.log(
+            'Offer amounts match:',
+            offerAmount === offerAmountFromCopyAdScreen
+          )
+        })
+      if (rateType == 'Fixed Rate') {
         cy.findByTestId('fixed_rate_type')
           .invoke('val')
           .then((rateValueFromCopyAdScreen) => {
@@ -166,37 +305,96 @@ Cypress.Commands.add(
               rateValue === rateValueFromCopyAdScreen
             )
           })
-        cy.get('span[class="dc-text"]')
-          .contains('Instructions')
-          .next()
-          .invoke('text')
-          .then((instructionsFromCopyAdScreen) => {
+      } else if (rateType == 'Floating Rate') {
+        cy.findByTestId('float_rate_type')
+          .invoke('val')
+          .then((rateValueFromCopyAdScreen) => {
             cy.log(
               'Offer amounts match:',
-              instructions === instructionsFromCopyAdScreen
+              rateValue === rateValueFromCopyAdScreen
             )
           })
-        cy.get('span[class="dc-text"]')
-          .contains('Order must be completed in')
-          .next()
-          .invoke('text')
-          .then((orderCompletionTimeFromCopyAds) => {
-            cy.log(
-              'Offer amounts match:',
-              orderCompletionTime === orderCompletionTimeFromCopyAds
-            )
-          })
-        cy.findByTestId('offer_amount')
-          .clear()
-          .type(parseFloat(offerAmount) + 1)
-          .should('have.value', parseFloat(offerAmount) + 1)
-      } else if (adType == 'Sell' && rateType == 'Fixed Rate') {
-      } else if (adType == 'Buy' && rateType == 'Floating Rate') {
-      } else if (adType == 'Sell' && rateType == 'Floating Rate') {
       }
+      if (adType == 'Sell') {
+        cy.get('span[class="dc-text"]')
+          .contains('Contact details')
+          .next()
+          .invoke('text')
+          .then((contactDetailsFromCopyAdScreen) => {
+            cy.log(
+              'Offer amounts match:',
+              contactDetails === contactDetailsFromCopyAdScreen
+            )
+          })
+      }
+      cy.get('span[class="dc-text"]')
+        .contains('Instructions')
+        .next()
+        .invoke('text')
+        .then((instructionsFromCopyAdScreen) => {
+          cy.log(
+            'Offer amounts match:',
+            instructions === instructionsFromCopyAdScreen
+          )
+        })
+      cy.get('span[class="dc-text"]')
+        .contains('Order must be completed in')
+        .next()
+        .invoke('text')
+        .then((orderCompletionTimeFromCopyAds) => {
+          cy.log(
+            'Offer amounts match:',
+            orderCompletionTime === orderCompletionTimeFromCopyAds
+          )
+        })
+      cy.findByTestId('offer_amount')
+        .clear()
+        .type(parseFloat(offerAmount) + 1)
+        .should('have.value', parseFloat(offerAmount) + 1)
+      if (rateType == 'Fixed Rate') {
+        cy.findByTestId('fixed_rate_type')
+          .clear()
+          .type(parseFloat(rateValue) + 1)
+          .should('have.value', parseFloat(rateValue) + 1)
+      } else if (rateType == 'Floating Rate') {
+        cy.findByTestId('float_rate_type')
+          .clear()
+          .type(parseFloat(rateValue) + 1)
+          .should('have.value', parseFloat(rateValue) + 1)
+      }
+      cy.findByTestId('min_transaction')
+        .clear()
+        .type(parseFloat(offerAmount) + 1)
+        .should('have.value', parseFloat(offerAmount) + 1)
+      cy.findByTestId('max_transaction')
+        .clear()
+        .type(parseFloat(offerAmount) + 1)
+        .should('have.value', parseFloat(offerAmount) + 1)
+      cy.findByRole('button', { name: 'Create ad' })
+        .should('be.enabled')
+        .click()
+      cy.findByText("You've created an ad").should('be.visible')
+      cy.findByText(
+        "If the ad doesn't receive an order for 3 days, it will be deactivated."
+      ).should('be.visible')
+      cy.findByText('Don’t show this message again.').should('be.visible')
+      cy.findByRole('button', { name: 'Ok' }).should('be.enabled').click()
     })
   }
 )
+
+Cypress.Commands.add('c_deleteCopiedAd', () => {
+  cy.get('.my-ads-table__row .dc-dropdown-container')
+    .eq(0)
+    .should('be.visible')
+    .click()
+  cy.findByText('Delete').parent().click()
+  cy.findByText('Do you want to delete this ad?').should('be.visible')
+  cy.findByText('You will NOT be able to restore it.').should('be.visible')
+  cy.findByRole('button', { name: 'Cancel' }).should('be.enabled')
+  cy.findByRole('button', { name: 'Delete' }).should('be.enabled').click()
+  cy.findByText('Hide my ads').should('be.visible')
+})
 
 Cypress.Commands.add('c_verifyRate', () => {
   cy.findByTestId('float_rate_type').click().clear()


### PR DESCRIPTION
Automated new feature for P2P that got released in this Sprint, Copy Ads. 

1. It will first check for an existing Buy Ad,

> If an ad is available -> Go to Step 2
> If no ad available -> Go to Step 3

2. It will first get the existing ads content
- Now, from the dropdown, select Copy
- It will then compare the content of the ad with the already existing ad
- Then, it will create a new ad by using the Copy feature. 
- Delete the newly created copied ad. 

3. It will first create an ad
- Get the existing ads content,
- From the newly created ad, from it's dropdown it will select Copy.
- It will then compare the content of the ad with the already existing ad
- Then, it will create a new ad by using the Copy feature. 
- Delete the newly created copied ad. 


Extras: Added support for future tests (reusable functions)
- Sell-type ad
- Float-rate type ad


[Cypress test for QATEST-145618 Copy Ad - Fixed Rate - Buy Ad](https://app.clickup.com/t/20696747/P2PS-2838)

![image](https://github.com/deriv-com/e2e-deriv-app/assets/152943428/d5bcc8e6-9394-46ca-97ce-b688132d6b66)
