### PR TITLE
Updated email verification locator

### DIFF
--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -374,8 +374,13 @@ Cypress.Commands.add(
           if (allRelatedEmails.length) {
             const verificationEmail = allRelatedEmails.pop()
             cy.wrap(verificationEmail).click()
-            cy.contains('p', `${accountEmail}`).last().should('be.visible')
-            cy.contains('a', Cypress.config('baseUrl'))
+            cy.get('p')
+              .filter(`:contains('${accountEmail}')`)
+              .last()
+              .should('be.visible')
+              .parent()
+              .children()
+              .contains('a', Cypress.config('baseUrl'))
               .invoke('attr', 'href')
               .then((href) => {
                 if (href) {
@@ -435,7 +440,8 @@ Cypress.Commands.add(
       if (allRelatedEmails.length) {
         const verificationEmail = allRelatedEmails.pop()
         cy.wrap(verificationEmail).click()
-        cy.contains('p', `${accountEmail}`)
+        cy.get('p')
+          .filter(`:contains('${accountEmail}')`)
           .last()
           .should('be.visible')
           .parent()


### PR DESCRIPTION
`cy.contains()` only picks the first element so it will fail if there are two emails with same email address. Later, I will check and merge `c_emailVerifcation()` and `c_emailVerificationV2()` so we have only one command; but this is a quick fix for now. I've tested locally.