### PR TITLE
P2P - inputAdCreation function update

### DIFF
--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -153,8 +153,7 @@ Cypress.Commands.add(
           sessionStorage.setItem('c_localCurrency', localCurrency.trim())
         })
     } else if (rateType == 'float') {
-      cy.findByTestId('float_rate_type')
-        .next('span.dc-text')
+      cy.get('.floating-rate__hint')
         .invoke('text')
         .then((localCurrency) => {
           sessionStorage.setItem('c_localCurrency', localCurrency.trim())
@@ -168,6 +167,7 @@ Cypress.Commands.add(
           .should('have.value', rateValue)
       } else if (rateType == 'float') {
         cy.findByTestId('float_rate_type')
+          .clear()
           .type(rateValue)
           .should('have.value', rateValue)
       }
@@ -201,11 +201,11 @@ Cypress.Commands.add(
           .find('.dc-checkbox')
           .and('exist')
           .click()
+        cy.findByRole('button', { name: 'Next' }).should('be.enabled').click()
+        cy.findByText('Set ad conditions').should('be.visible')
       } else if (adType == 'Buy') {
         cy.c_PaymentMethod()
       }
-      cy.findByRole('button', { name: 'Next' }).should('be.enabled').click()
-      cy.findByText('Set ad conditions').should('be.visible')
       cy.c_verifyPostAd()
       cy.c_verifyAdOnMyAdsScreen(
         adType,
@@ -213,7 +213,8 @@ Cypress.Commands.add(
         sessionStorage.getItem('c_localCurrency'),
         rateValue,
         minOrder,
-        maxOrder
+        maxOrder,
+        rateType
       )
     })
   }
@@ -221,13 +222,25 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'c_verifyAdOnMyAdsScreen',
-  (adType, fiatCurrency, localCurrency, rateValue, minOrder, maxOrder) => {
+  (
+    adType,
+    fiatCurrency,
+    localCurrency,
+    rateValue,
+    minOrder,
+    maxOrder,
+    rateType
+  ) => {
     cy.findByText('Active').should('be.visible')
     cy.findByText(`${adType} ${fiatCurrency}`).should('be.visible')
-    cy.findByText(`${rateValue} ${localCurrency}`)
+    if (rateType === 'float') {
+      cy.findByText(`+${rateValue}%`).should('be.visible')
+    } else if (rateType === 'fixed') {
+      cy.findByText(`${rateValue} ${localCurrency}`).should('be.visible')
+    }
     cy.findByText(
       `${minOrder.toFixed(2)} - ${maxOrder.toFixed(2)} ${fiatCurrency}`
-    )
+    ).should('be.visible')
   }
 )
 


### PR DESCRIPTION
In this PR, I have updated function inputAdDetails in p2p.js to follow the updated ad creation flow due to Ad Terms. 

[Cron Failure](https://cloud.cypress.io/projects/9szghx/runs/72/overview/ceee9d0f-c2ec-41ef-9a4a-49b7c0d3fc79/replay?roarHideRunsWithDiffGroupsAndTags=1)

[ClickUp Card](https://app.clickup.com/t/86byz9tnu)