### PR TITLE
Creating account with affiliate token

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -392,6 +392,8 @@ module.exports = defineConfig({
     appRegisterUrl: process.env.E2E_APP_REGISTER_URL,
     passkeyUrl: process.env.E2E_PASSKEY_URL,
     passkeyAppId: process.env.E2E_PASSKEY_APP_ID,
+    trackingLink: process.env.E2E_TRACKING_LINK,
+    trackingLinkToken: process.env.E2E_TRACKING_LINK_TOKEN,
     countries: {
       ZA: "South Africa",
       CO: "Colombia",

--- a/cypress/e2e/smoke/Marketing/accountSignupAffiliate.cy.js
+++ b/cypress/e2e/smoke/Marketing/accountSignupAffiliate.cy.js
@@ -1,4 +1,3 @@
-import '@testing-library/cypress/add-commands'
 import { generateEpoch } from '../../../support/helper/utility'
 
 describe('QATEST-122929 - Creating account with affiliate token', () => {
@@ -38,7 +37,7 @@ describe('QATEST-122929 - Creating account with affiliate token', () => {
       cy.window().scrollTo('center', {
         ensureScrollable: false,
       })
-      cy.findByRole('link', { name: /View affiliate details/i })
+
       cy.contains(
         'This is the token currently registered with MyAffiliates.'
       ).should('be.visible')

--- a/cypress/e2e/smoke/Marketing/accountSignupAffiliate.cy.js
+++ b/cypress/e2e/smoke/Marketing/accountSignupAffiliate.cy.js
@@ -1,0 +1,50 @@
+import '@testing-library/cypress/add-commands'
+import { generateEpoch } from '../../../support/helper/utility'
+
+describe('QATEST-122929 - Creating account with affiliate token', () => {
+  const size = ['desktop', 'small']
+  let countryIDV = Cypress.env('countries').ID
+  const BO_URL = `https://${Cypress.env('configServer')}${Cypress.env('qaBOEndpoint')}`
+  const tracking_Link_URL = `https://${Cypress.env('trackingLink')}${Cypress.env('trackingLinkToken')}`
+
+  size.forEach((size) => {
+    it(`affliate token should be attached to the account created (check in BO affiliate token) ${size == 'small' ? 'mobile' : 'desktop'}`, () => {
+      const isMobile = size == 'small' ? true : false
+      cy.c_visitResponsive(tracking_Link_URL, size)
+      cy.url().then((url) => {
+        cy.log('The current URL is:', url)
+        var longURL = new URL(url)
+        var affiliate_token = longURL.searchParams.get('t')
+        cy.wrap(affiliate_token).as('token')
+      })
+
+      const signUpEmail = `sanity${generateEpoch()}affiliate@deriv.com`
+      cy.c_setEndpoint(signUpEmail, size)
+      cy.c_demoAccountSignup(countryIDV, signUpEmail, size)
+
+      /* Visit BO */
+      cy.c_visitResponsive('/', 'large')
+      cy.visit(BO_URL)
+      cy.findByText('Please login.').click()
+      cy.findByText('Client Management').click()
+      cy.findByPlaceholderText('email@domain.com')
+        .should('exist')
+        .clear()
+        .type(signUpEmail)
+      cy.findByRole('button', { name: /View \/ Edit/i }).click()
+      cy.get('.link').eq(1).should('be.visible').click()
+
+      /*  Verify that the account has affiliate token attached to it */
+      cy.window().scrollTo('center', {
+        ensureScrollable: false,
+      })
+      cy.findByRole('link', { name: /View affiliate details/i })
+      cy.contains(
+        'This is the token currently registered with MyAffiliates.'
+      ).should('be.visible')
+      cy.get('@token').then((token) => {
+        cy.contains(token).should('be.visible')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Summary
Added e2e that creates demo account using affiliate signup link and verifies that the account has affiliate token attached to it.

Ticket
https://app.clickup.com/t/20696747/MARK-1243

Notes
Tests is executable for mobile and desktop resolutions
![image](https://github.com/deriv-com/e2e-deriv-app/assets/167836892/355d0760-137d-40d2-8fe6-8e790166bb50)
