### PR TITLE
Removal of .clear due to cron failure. 

### DIFF
--- a/cypress/e2e/smoke/P2P/createBuyOrderFloatingRate.cy.js
+++ b/cypress/e2e/smoke/P2P/createBuyOrderFloatingRate.cy.js
@@ -1,4 +1,4 @@
-let floatRate = 0.01
+let floatRate = 1
 let minOrder = 1
 let maxOrder = 10
 let nicknameAndAmount = {

--- a/cypress/e2e/smoke/P2P/createBuyOrderFloatingRate.cy.js
+++ b/cypress/e2e/smoke/P2P/createBuyOrderFloatingRate.cy.js
@@ -1,10 +1,10 @@
-let floatRate = 1.25
+let floatRate = 0.01
 let minOrder = 1
 let maxOrder = 10
 let nicknameAndAmount = {
   sellerBalanceBeforeSelling: '',
   sellerBalanceAfterSelling: '',
-  buyerBalanceBeforeBuying: '9750',
+  buyerBalanceBeforeBuying: '',
   buyerBalanceAfterBuying: '',
   buyer: '',
   seller: '',

--- a/cypress/e2e/smoke/P2P/createBuyOrderFloatingRate.cy.js
+++ b/cypress/e2e/smoke/P2P/createBuyOrderFloatingRate.cy.js
@@ -1,4 +1,4 @@
-let floatRate = 1
+let floatRate = 0.01
 let minOrder = 1
 let maxOrder = 10
 let nicknameAndAmount = {

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -166,11 +166,11 @@ Cypress.Commands.add(
         cy.findByTestId('fixed_rate_type')
           .type(rateValue)
           .should('have.value', rateValue)
-      } else if (rateType == 'float') {
-        cy.findByTestId('float_rate_type').clear()
-        cy.findByTestId('float_rate_type')
-          .type(rateValue)
-          .should('have.value', rateValue)
+        // } else if (rateType == 'float') {
+        //   cy.findByTestId('float_rate_type').clear()
+        //   cy.findByTestId('float_rate_type')
+        //     .type(rateValue)
+        //     .should('have.value', rateValue)
       }
       cy.findByTestId('min_transaction')
         .type(minOrder)

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -168,7 +168,9 @@ Cypress.Commands.add(
           .should('have.value', rateValue)
       } else if (rateType == 'float') {
         //   cy.findByTestId('float_rate_type').clear()
-        cy.findByTestId('float_rate_type').type(rateValue)
+        cy.findByTestId('float_rate_type')
+          .type(rateValue)
+          .should('have.value', '+'.concat(rateValue))
       }
       cy.findByTestId('min_transaction')
         .type(minOrder)

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -166,11 +166,11 @@ Cypress.Commands.add(
         cy.findByTestId('fixed_rate_type')
           .type(rateValue)
           .should('have.value', rateValue)
-        // } else if (rateType == 'float') {
+      } else if (rateType == 'float') {
         //   cy.findByTestId('float_rate_type').clear()
-        //   cy.findByTestId('float_rate_type')
-        //     .type(rateValue)
-        //     .should('have.value', rateValue)
+        cy.findByTestId('float_rate_type')
+          .type(rateValue)
+          .should('have.value', rateValue)
       }
       cy.findByTestId('min_transaction')
         .type(minOrder)

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -168,9 +168,7 @@ Cypress.Commands.add(
           .should('have.value', rateValue)
       } else if (rateType == 'float') {
         //   cy.findByTestId('float_rate_type').clear()
-        cy.findByTestId('float_rate_type')
-          .type(rateValue)
-          .should('have.value', rateValue)
+        cy.findByTestId('float_rate_type').type(rateValue)
       }
       cy.findByTestId('min_transaction')
         .type(minOrder)

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -167,10 +167,10 @@ Cypress.Commands.add(
           .type(rateValue)
           .should('have.value', rateValue)
       } else if (rateType == 'float') {
-        cy.findByTestId('float_rate_type')
-          .clear()
-          .type(rateValue)
-          .should('have.value', '+'.concat(rateValue))
+        cy.findByTestId('float_rate_type').should(
+          'have.value',
+          '+'.concat(rateValue)
+        )
       }
       cy.findByTestId('min_transaction')
         .type(minOrder)

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -167,7 +167,7 @@ Cypress.Commands.add(
           .type(rateValue)
           .should('have.value', rateValue)
       } else if (rateType == 'float') {
-        //   cy.findByTestId('float_rate_type').clear()
+        cy.findByTestId('float_rate_type').clear()
         cy.findByTestId('float_rate_type')
           .type(rateValue)
           .should('have.value', '+'.concat(rateValue))

--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -167,8 +167,8 @@ Cypress.Commands.add(
           .type(rateValue)
           .should('have.value', rateValue)
       } else if (rateType == 'float') {
-        cy.findByTestId('float_rate_type').clear()
         cy.findByTestId('float_rate_type')
+          .clear()
           .type(rateValue)
           .should('have.value', '+'.concat(rateValue))
       }


### PR DESCRIPTION
Cron was failing 3 days at the same code line. As it was found, there was an issue with the .clear() method for the float rate type. 

More info on the [ClickUp Card](https://app.clickup.com/t/86bz5wne5).

[Cron Fail on Wednesday](https://deriv-group.slack.com/archives/C047YVCLCJX/p1718157064630319)
[Cron Fail on Tuesday](https://deriv-group.slack.com/archives/C047YVCLCJX/p1718070544772859)
[Cron Fail on Monday](https://deriv-group.slack.com/archives/C047YVCLCJX/p1717984161909249)

All failed at the point of .clear() being called. 