### PR TITLE
Update Login/Logout test

### DIFF
--- a/cypress/e2e/smoke/TradersHub/uiLoginLogout.cy.js
+++ b/cypress/e2e/smoke/TradersHub/uiLoginLogout.cy.js
@@ -13,9 +13,17 @@ describe('QATEST-103970: Verify user can successfully login and logout', () => {
       cy.findByLabelText('Email').type(username)
       cy.findByLabelText('Password').type(password, { log: false })
       cy.findByRole('button', { name: 'Log in' }).click()
-      //Verify home page has successfully loaded
       cy.findAllByTestId('dt_balance_text_container').should('have.length', '2')
-      if (isMobile) cy.c_skipPasskeysV2()
+      //Verify home page has successfully loaded
+      if (isMobile) {
+        cy.c_skipPasskeysV2()
+        cy.findByRole('button', { name: 'Cashier' }).should('be.visible')
+      } else cy.findByTitle('Cashier').should('be.visible')
+      cy.findByText('Join over 2.5 million traders').should('not.exist')
+      cy.findByRole('button', { name: 'Log in' }).should('not.exist')
+      cy.findByRole('button', { name: 'Sign up' }).should('not.exist')
+      cy.findByRole('button', { name: 'Get Started' }).should('not.exist')
+      cy.c_checkTradersHubHomePage(isMobile)
       //Logout
       if (isMobile) {
         derivApp.commonPage.mobileLocators.header.hamburgerMenuButton().click()
@@ -27,10 +35,14 @@ describe('QATEST-103970: Verify user can successfully login and logout', () => {
         cy.get('.traders-hub-header__setting').click()
         cy.findByTestId('dt_logout_tab').click()
       }
-      cy.findByText('Trading for anyone. Anywhere. Anytime.').should(
-        'be.visible'
-      )
-      cy.url().should('eq', Cypress.env('derivComProdURL'))
+      cy.findByText('Join over 2.5 million traders').should('be.visible')
+      cy.findByRole('button', { name: 'Log in' }).should('be.visible')
+      cy.findByRole('button', { name: 'Sign up' }).should('be.visible')
+      cy.findByRole('button', { name: 'Get Started' }).should('be.visible')
+      if (isMobile)
+        cy.findByRole('button', { name: 'Cashier' }).should('not.exist')
+      else cy.findByTitle('Cashier').should('not.exist')
+      cy.url().should('eq', Cypress.config('baseUrl'))
     })
   })
 })


### PR DESCRIPTION
- Earlier, user routed to deriv.com after logout, now they go to logged out version of traders hub. Updated the test accordingly
- Added some more assertions.

[Test workflow](https://github.com/regentmarkets/e2e-deriv-app/actions/runs/9477478177)