### PR TITLE
Merge c_emailVerificationV2 into c_emailVerification

### DIFF
--- a/cypress/e2e/smoke/Wallets/mt5ResetPasswordResponsive.cy.js
+++ b/cypress/e2e/smoke/Wallets/mt5ResetPasswordResponsive.cy.js
@@ -38,7 +38,10 @@ function changeMT5Password() {
             cy.c_emailVerification(
               'New%20DMT5%20password%20request.html',
               'QA script',
-              { baseUrl: Cypress.env('configServer') + '/emails' }
+              {
+                baseUrl: Cypress.env('configServer') + '/emails',
+                isMT5ResetPassword: true,
+              }
             )
             cy.then(() => {
               cy.c_visitResponsive(Cypress.env('verificationUrl'), 'large')

--- a/cypress/support/commands/common.js
+++ b/cypress/support/commands/common.js
@@ -322,6 +322,7 @@ Cypress.Commands.add(
       maxRetries = 3,
       baseUrl = Cypress.env('configServer') + '/events',
       isMT5ResetPassword = false,
+      isViaAPI = false,
     } = options
     cy.log(`Visit ${baseUrl}`)
     const userID = Cypress.env('qaBoxLoginEmail')
@@ -337,8 +338,11 @@ Cypress.Commands.add(
         'qaBoxLoginPassword',
         { log: false }
       )}@${baseUrl}`,
-      { args: [requestType, accountEmail, isMT5ResetPassword] },
-      ([requestType, accountEmail, isMT5ResetPassword]) => {
+      {
+        args: [requestType, accountEmail, isMT5ResetPassword, isViaAPI],
+      },
+      ([requestType, accountEmail, isMT5ResetPassword, isViaAPI]) => {
+        let verification_code
         cy.document().then((doc) => {
           const allRelatedEmails = Array.from(
             doc.querySelectorAll(`a[href*="${requestType}"]`)
@@ -346,52 +350,41 @@ Cypress.Commands.add(
           if (allRelatedEmails.length) {
             const verificationEmail = allRelatedEmails.pop()
             cy.wrap(verificationEmail).click()
-            if (isMT5ResetPassword) {
-              cy.get('p')
-                .should('be.visible')
-                .parent()
-                .children()
-                .contains('a', Cypress.config('baseUrl'))
-                .invoke('attr', 'href')
-                .then((href) => {
-                  if (href) {
-                    Cypress.env('verificationUrl', href)
-                    cy.log('MT5 reset password link found')
-                  } else {
-                    cy.log('MT5 reset password link not found')
-                  }
-                })
-            } else {
-              cy.get('p')
-                .filter(`:contains('${accountEmail}')`)
-                .last()
-                .should('be.visible')
-                .parent()
-                .children()
-                .contains('a', Cypress.config('baseUrl'))
-                .invoke('attr', 'href')
-                .then((href) => {
-                  if (href) {
-                    Cypress.env('verificationUrl', href)
-                    const code = href.match(/code=([A-Za-z0-9]{8})/)
-                    verification_code = code[1]
-                    Cypress.env('walletsWithdrawalCode', verification_code)
-                    cy.log('Verification link found')
-                  } else {
-                    cy.log('Verification link not found')
-                  }
-                })
-            }
+            ;(() =>
+              isMT5ResetPassword
+                ? cy.get('p')
+                : cy.get('p').filter(`:contains('${accountEmail}')`).last())()
+              .should('be.visible')
+              .parent()
+              .children()
+              .contains('a', Cypress.config('baseUrl'))
+              .invoke('attr', 'href')
+              .then((href) => {
+                if (href) {
+                  Cypress.env('verificationUrl', href)
+                  const code = href.match(/code=([A-Za-z0-9]{8})/)
+                  verification_code = code[1]
+                  isViaAPI
+                    ? cy.task('setVerificationCode', verification_code)
+                    : Cypress.env('walletsWithdrawalCode', verification_code)
+                  cy.log('Verification link found')
+                } else {
+                  cy.log('Verification link not found')
+                }
+              })
           } else {
             cy.log('email not found')
           }
         })
       }
     )
+    cy.on('fail', (err) => {
+      rotateCreds()
+      throw err
+    })
     cy.then(() => {
       //Rotating credentials
-      Cypress.env('qaBoxLoginEmail', userID)
-      Cypress.env('qaBoxLoginPassword', userPSWD)
+      rotateCreds()
       //Retry finding email after 1 second interval
       if (retryCount < maxRetries && !Cypress.env('verificationUrl')) {
         cy.log(`Retrying... Attempt number: ${retryCount + 1}`)
@@ -407,51 +400,10 @@ Cypress.Commands.add(
         )
       }
     })
-  }
-)
-
-Cypress.Commands.add(
-  'c_emailVerificationV2',
-  (requestType, accountEmail, options = {}) => {
-    const { baseUrl = Cypress.env('configServer') + '/events' } = options
-    cy.log(`Visit ${baseUrl}`)
-    cy.visit(
-      `https://${Cypress.env('qaBoxLoginEmail')}:${Cypress.env(
-        'qaBoxLoginPassword'
-      )}@${baseUrl}`,
-      { log: false }
-    )
-    cy.document().then((doc) => {
-      let verification_code
-      const allRelatedEmails = Array.from(
-        doc.querySelectorAll(`a[href*="${requestType}"]`)
-      )
-      if (allRelatedEmails.length) {
-        const verificationEmail = allRelatedEmails.pop()
-        cy.wrap(verificationEmail).click()
-        cy.get('p')
-          .filter(`:contains('${accountEmail}')`)
-          .last()
-          .should('be.visible')
-          .parent()
-          .children()
-          .contains('a', Cypress.config('baseUrl'))
-          .invoke('attr', 'href')
-          .then((href) => {
-            if (href) {
-              Cypress.env('verificationUrl', href)
-              const code = href.match(/code=([A-Za-z0-9]{8})/)
-              verification_code = code[1]
-              cy.task('setVerificationCode', verification_code)
-              cy.log('Verification link found')
-            } else {
-              cy.log('Verification link not found')
-            }
-          })
-      } else {
-        cy.log('email not found')
-      }
-    })
+    const rotateCreds = () => {
+      Cypress.env('qaBoxLoginEmail', userID)
+      Cypress.env('qaBoxLoginPassword', userPSWD)
+    }
   }
 )
 
@@ -542,7 +494,9 @@ Cypress.Commands.add(
     try {
       cy.task('wsConnect')
       cy.task('verifyEmailTask').then((accountEmail) => {
-        cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
+        cy.c_emailVerification('account_opening_new.html', accountEmail, {
+          isViaAPI: true,
+        })
         cy.task('createRealAccountTask', {
           country_code: country_code,
           currency: currency,
@@ -571,7 +525,9 @@ Cypress.Commands.add(
     try {
       cy.task('wsConnect')
       cy.task('verifyEmailTask').then((accountEmail) => {
-        cy.c_emailVerificationV2('account_opening_new.html', accountEmail)
+        cy.c_emailVerification('account_opening_new.html', accountEmail, {
+          isViaAPI: true,
+        })
         cy.task('createVirtualAccountTask', {
           country_code: country_code,
           currency: currency,


### PR DESCRIPTION
1. Main change:
    - Added optional param `isViaAPI` in `c_emailVerification` to run task for api account creation
    - Updated the locator to get verification link to use arrow function to reduce duplicate code
    - Handled scenario where credentials were not rotated if c_emailVerification throws error
2. Minor: added `isMT5ResetPassword: true,` in e2e/smoke/Wallets/mt5ResetPasswordResponsive.cy.js