### PR TITLE
PassKeys PopUp at Random Times

### DIFF
--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -588,9 +588,18 @@ Cypress.Commands.add('c_verifyDynamicMsg', () => {
 })
 
 Cypress.Commands.add('c_navigateToDerivP2P', () => {
+  cy.c_rateLimit({
+    waitTimeAfterError: 15000,
+    isLanguageTest: true,
+    maxRetries: 5,
+  })
+  cy.c_skipPasskey()
   cy.get('#dt_mobile_drawer_toggle').should('be.visible').click()
+  cy.c_skipPasskey()
   cy.findByRole('heading', { name: 'Cashier' }).should('be.visible').click()
+  cy.c_skipPasskey()
   cy.findByRole('link', { name: 'Deriv P2P' }).should('be.visible').click()
+  cy.c_skipPasskey()
 })
 
 Cypress.Commands.add('c_deleteAllPM', () => {


### PR DESCRIPTION
It is noted that the PassKeys popup screen comes up at different times in some QABox due to performance difference from QA10 and speed of Cypress. 

To handle this, I have added skipPasskeys() function after step of navigating into P2P. 