### PR TITLE
update

### DIFF
--- a/cypress/e2e/smoke/Wallets/cryptoTransactions.cy.js
+++ b/cypress/e2e/smoke/Wallets/cryptoTransactions.cy.js
@@ -75,7 +75,7 @@ describe('QATEST-98789 - Transfer to crypto accounts and QATEST-98794 View Crypt
       cy.log('Transfer from Crypto account')
       cy.findByText(/Wallet/, { timeout: 10000 }).should('exist')
       cy.c_visitResponsive('/', 'large')
-      cy.c_setupTradeAccount('BTC')
+      cy.c_setupTradeAccount('BTC', 'log the result')
       cy.c_switchWalletsAccount('BTC')
       cy.contains('Transfer').click()
       crypto_transfer('USD Wallet', transferAmount)

--- a/cypress/e2e/smoke/Wallets/cryptoTransactions.cy.js
+++ b/cypress/e2e/smoke/Wallets/cryptoTransactions.cy.js
@@ -75,7 +75,7 @@ describe('QATEST-98789 - Transfer to crypto accounts and QATEST-98794 View Crypt
       cy.log('Transfer from Crypto account')
       cy.findByText(/Wallet/, { timeout: 10000 }).should('exist')
       cy.c_visitResponsive('/', 'large')
-      cy.c_setupTradeAccount('BTC', 'log the result')
+      cy.c_setupTradeAccount('BTC', false)
       cy.c_switchWalletsAccount('BTC')
       cy.contains('Transfer').click()
       crypto_transfer('USD Wallet', transferAmount)

--- a/cypress/support/commands/wallets.js
+++ b/cypress/support/commands/wallets.js
@@ -87,7 +87,7 @@ Cypress.Commands.add('c_checkForBanner', () => {
   cy.findByText('Enjoy seamless transactions').should('not.exist')
 })
 
-Cypress.Commands.add('c_setupTradeAccount', (wallet, action = 'Fail') => {
+Cypress.Commands.add('c_setupTradeAccount', (wallet, requireNew = true) => {
   cy.c_switchWalletsAccount(wallet)
   cy.findByRole('button', { name: 'Get' })
     .should(() => {})
@@ -104,7 +104,7 @@ Cypress.Commands.add('c_setupTradeAccount', (wallet, action = 'Fail') => {
           .findByText("Trader's Hub")
           .should('be.visible')
       } else {
-        if (action == 'Fail') {
+        if (requireNew) {
           cy.fail('Trading account already added')
         } else {
           cy.log('Trading account already added')

--- a/cypress/support/commands/wallets.js
+++ b/cypress/support/commands/wallets.js
@@ -87,7 +87,7 @@ Cypress.Commands.add('c_checkForBanner', () => {
   cy.findByText('Enjoy seamless transactions').should('not.exist')
 })
 
-Cypress.Commands.add('c_setupTradeAccount', (wallet) => {
+Cypress.Commands.add('c_setupTradeAccount', (wallet, action = 'Fail') => {
   cy.c_switchWalletsAccount(wallet)
   cy.findByRole('button', { name: 'Get' })
     .should(() => {})
@@ -104,7 +104,11 @@ Cypress.Commands.add('c_setupTradeAccount', (wallet) => {
           .findByText("Trader's Hub")
           .should('be.visible')
       } else {
-        cy.fail('Trading account already added')
+        if (`${action}` == 'Fail') {
+          cy.fail('Trading account already added')
+        } else {
+          cy.log('Trading account already added')
+        }
       }
     })
 })

--- a/cypress/support/commands/wallets.js
+++ b/cypress/support/commands/wallets.js
@@ -104,7 +104,7 @@ Cypress.Commands.add('c_setupTradeAccount', (wallet, action = 'Fail') => {
           .findByText("Trader's Hub")
           .should('be.visible')
       } else {
-        if (`${action}` == 'Fail') {
+        if (action == 'Fail') {
           cy.fail('Trading account already added')
         } else {
           cy.log('Trading account already added')


### PR DESCRIPTION
`c_setupTradeAccount` is utilized across various tests to add a trading account if it is absent. Currently, it consistently fails when attempting to add an existing trading account. The task is to modify this function to either return the status or appropriately fail the test according to the specific test requirements.
CU: https://app.clickup.com/t/20696747/WALL-4460