### PR TITLE
P2P - Removed dependency on Existence of IDR Ads

### DIFF
--- a/cypress/e2e/full/P2P/verifyEmptyStateAdScreen.cy.js
+++ b/cypress/e2e/full/P2P/verifyEmptyStateAdScreen.cy.js
@@ -1,10 +1,8 @@
-let currency = {
-  name: 'Indonesian Rupiah',
-  code: 'IDR',
-}
-
 describe('QATEST-2538 Empty State/Buy Sell Page', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage()
+    cy.clearAllSessionStorage()
+    cy.clearAllCookies()
     cy.c_login({ user: 'p2pVerifyEmptyStateAdScreen' })
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })
@@ -15,10 +13,25 @@ describe('QATEST-2538 Empty State/Buy Sell Page', () => {
     cy.c_checkForEmptyAdScreenMessage('Sell', 'Buy')
     cy.findByTestId('dt_dropdown_container').should('be.visible').click()
     cy.findByText('Preferred currency').should('be.visible')
-    cy.findByText(currency.name).should('be.visible').click()
-    cy.findByTestId('dt_dropdown_container')
-      .find('.dc-dropdown__display-text')
-      .should('have.text', currency.code)
-    cy.c_checkForNonEmptyStateAdScreen()
+    cy.get('.dc-dropdown-list__item')
+      .eq(1)
+      .within(() => {
+        cy.get('.currency-dropdown__list-item-symbol')
+          .invoke('text')
+          .then((currencyCode) => {
+            const currency = currencyCode.trim()
+            sessionStorage.setItem('c_currencyCode', currency)
+            cy.findByText(sessionStorage.getItem('c_currencyCode'))
+              .should('be.visible')
+              .click()
+          })
+      })
+    cy.then(() => {
+      cy.findByTestId('dt_dropdown_container')
+        .find('.dc-dropdown__display-text')
+        .should('have.text', sessionStorage.getItem('c_currencyCode'))
+      cy.c_checkForNonEmptyStateAdScreen()
+      cy.c_checkForNonEmptyStateAdScreen()
+    })
   })
 })

--- a/cypress/e2e/full/P2P/verifyEmptyStateAdScreen.cy.js
+++ b/cypress/e2e/full/P2P/verifyEmptyStateAdScreen.cy.js
@@ -1,8 +1,5 @@
 describe('QATEST-2538 Empty State/Buy Sell Page', () => {
   beforeEach(() => {
-    cy.clearAllLocalStorage()
-    cy.clearAllSessionStorage()
-    cy.clearAllCookies()
     cy.c_login({ user: 'p2pVerifyEmptyStateAdScreen' })
     cy.c_visitResponsive('/appstore/traders-hub', 'small')
   })

--- a/cypress/e2e/full/P2P/verifyEmptyStateAdScreen.cy.js
+++ b/cypress/e2e/full/P2P/verifyEmptyStateAdScreen.cy.js
@@ -31,7 +31,6 @@ describe('QATEST-2538 Empty State/Buy Sell Page', () => {
         .find('.dc-dropdown__display-text')
         .should('have.text', sessionStorage.getItem('c_currencyCode'))
       cy.c_checkForNonEmptyStateAdScreen()
-      cy.c_checkForNonEmptyStateAdScreen()
     })
   })
 })


### PR DESCRIPTION
In this PR, I have removed dependency for ads to exist in IDR currency. Otherwise, this test would fail and it seemed flaky in this case. Hence, it will now pick whatever currency is available from the dropdown list and verifies the currency is opened that is clicked on and the test's dependency is removed from IDR. 


[Run Workflow](https://github.com/regentmarkets/e2e-deriv-app/actions/runs/9710557392/job/26801493763)
