### PR TITLE
Flakiness Fix - Edit Ad Details

### DIFF
--- a/cypress/support/commands/p2p.js
+++ b/cypress/support/commands/p2p.js
@@ -1319,7 +1319,7 @@ Cypress.Commands.add(
     cy.findByText('30 days').should('be.visible').click()
     cy.findByText('90%').should('be.visible').click()
     cy.findByPlaceholderText('All countries').click()
-    cy.findByText('Preferred countries').should('be.visible')
+    cy.findAllByText('Preferred countries').should('be.visible')
     cy.findByText('All countries').should('be.visible').click()
     cy.findByText('Andorra').should('be.visible').click()
     cy.findByRole('button', { name: 'Apply' }).should('be.enabled').click()


### PR DESCRIPTION
Discovered a small flakiness due to the loading issue when clicking on All countries. Picks up Preferred Countries to be visible in the back screen due to load slow issue.

Note: The change done in [PR](https://github.com/deriv-com/e2e-deriv-app/pull/408) was reverted due to the merge of this [PR](https://github.com/deriv-com/e2e-deriv-app/pull/397) (maybe due to conflicts)

Hence, making this PR for the same change.

https://app.clickup.com/t/86bzduzqm